### PR TITLE
Add image URLs to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -83,17 +83,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Get all image files from the public folder and its subfolders
-  // const publicFolderPath = path.join(process.cwd(), 'public');
-  // const imageFiles = getAllImageFiles(publicFolderPath);
+  const publicFolderPath = path.join(process.cwd(), 'public');
+  const imageFiles = getAllImageFiles(publicFolderPath);
 
-  // Add image URLs to the sitemap
-  // imageFiles.forEach((file) => {
-  //   const relativePath = path.relative(publicFolderPath, file).replace(/\\/g, '/');
-  //   links.push({
-  //     url: `https://www.brinkdesign.co/${relativePath}`,
-  //     lastModified: new Date(),
-  //   });
-  // });
+  // Add image URLs to the sitemap with their last modified date
+  imageFiles.forEach((file) => {
+    const relativePath = path.relative(publicFolderPath, file).replace(/\\/g, '/');
+    const stat = fs.statSync(file);
+    links.push({
+      url: `https://www.brinkdesign.co/${relativePath}`,
+      lastModified: stat.mtime,
+    });
+  });
 
   return links;
 }


### PR DESCRIPTION
## Summary
- finalize sitemap logic
- gather images from public/ and include them in the sitemap

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c144618b08321a71e429b2f6e99f9