### PR TITLE
Add robots.txt metadata route

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: 'https://www.brinkdesign.co/sitemap.xml',
+  }
+}


### PR DESCRIPTION
## Summary
- add a `/robots` metadata route

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c14471bf88321890f010dcf738054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for generating a robots.txt file, allowing all search engines to access the site and providing a link to the sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->