### PR TITLE
Add OG image metadata to pages

### DIFF
--- a/src/app/commercial-av/page.tsx
+++ b/src/app/commercial-av/page.tsx
@@ -12,6 +12,14 @@ export const metadata: Metadata = {
             "Professional sound, display, and streaming solutions tailored for your business or organization in Rapid City.",
         url: "https://www.brinkdesign.co/commercial-av",
         type: "article",
+        images: [
+            {
+                url: 'https://www.brinkdesign.co/og-image.jpg',
+                width: 1200,
+                height: 630,
+                alt: 'Brink Design Co. AV Services',
+            },
+        ],
     },
 };
 

--- a/src/app/network-cabling/page.tsx
+++ b/src/app/network-cabling/page.tsx
@@ -12,6 +12,14 @@ export const metadata: Metadata = {
             "Professional network cabling, labeling, and testing for businesses and homes across Rapid City.",
         url: "https://www.brinkdesign.co/network-cabling",
         type: "article",
+        images: [
+            {
+                url: 'https://www.brinkdesign.co/og-image.jpg',
+                width: 1200,
+                height: 630,
+                alt: 'Brink Design Co. AV Services',
+            },
+        ],
     },
 };
 

--- a/src/app/photo-booth-opt-in/page.tsx
+++ b/src/app/photo-booth-opt-in/page.tsx
@@ -10,6 +10,14 @@ export const metadata: Metadata = {
             "Learn about our SMS photo delivery and privacy practices for Brink Design Co.'s photo booth.",
         url: "https://www.brinkdesign.co/photo-booth-opt-in",
         type: "article",
+        images: [
+            {
+                url: 'https://www.brinkdesign.co/og-image.jpg',
+                width: 1200,
+                height: 630,
+                alt: 'Brink Design Co. AV Services',
+            },
+        ],
     },
 };
 

--- a/src/app/security-installation/page.tsx
+++ b/src/app/security-installation/page.tsx
@@ -12,6 +12,14 @@ export const metadata: Metadata = {
             "Protect your home or business with reliable security systems installed by Brink Design Co.",
         url: "https://www.brinkdesign.co/security-installation",
         type: "article",
+        images: [
+            {
+                url: 'https://www.brinkdesign.co/og-image.jpg',
+                width: 1200,
+                height: 630,
+                alt: 'Brink Design Co. AV Services',
+            },
+        ],
     },
 };
 


### PR DESCRIPTION
## Summary
- include OpenGraph image metadata on Commercial AV page
- include OpenGraph image metadata on Network Cabling page
- include OpenGraph image metadata on Security Installation page
- include OpenGraph image metadata on Photo Booth Opt-In page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c19d868b883218d611f048c5583a8