### PR TITLE
Add canonical and twitter meta info

### DIFF
--- a/src/app/commercial-av/page.tsx
+++ b/src/app/commercial-av/page.tsx
@@ -21,6 +21,14 @@ export const metadata: Metadata = {
             },
         ],
     },
+    alternates: { canonical: "https://www.brinkdesign.co/commercial-av" },
+    twitter: {
+        card: "summary_large_image",
+        title: "Commercial AV Installation - Brink Design Co.",
+        description:
+            "Custom audio and video installations for Rapid City businesses, houses of worship, and classrooms. We design systems that just work — no guesswork.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
 };
 
 export default function CommercialAVPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,6 +4,13 @@ import ContactContainer from "@/components/contact_container";
 export const metadata: Metadata = {
   title: "Contact Us - Brink Design Co.",
   description: "Reach out to Brink Design Co. for professional AV installation, networking, security systems, and low voltage services. Let’s get your project started!",
+  alternates: { canonical: "https://www.brinkdesign.co/contact" },
+  twitter: {
+    card: "summary_large_image",
+    title: "Contact Us - Brink Design Co.",
+    description: "Reach out to Brink Design Co. for professional AV installation, networking, security systems, and low voltage services. Let’s get your project started!",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
 };
 
 export default function ContactPage() {

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,8 +1,9 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Mail, Phone } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { Metadata } from "next";
 
-export const metadata = {
+export const metadata: Metadata = {
     title: "FAQ – Brink Design Co.",
     description: "Frequently asked questions about AV installation, security cameras, networking, and more from Brink Design Co. Serving Rapid City and the Black Hills.",
     openGraph: {
@@ -18,6 +19,13 @@ export const metadata = {
                 alt: "Brink Design Co. AV Services",
             },
         ],
+    },
+    alternates: { canonical: "https://www.brinkdesign.co/faq" },
+    twitter: {
+        card: "summary_large_image",
+        title: "FAQ – Brink Design Co.",
+        description: "Frequently asked questions about AV installation, security cameras, networking, and more from Brink Design Co. Serving Rapid City and the Black Hills.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,13 @@ export const metadata: Metadata = {
       },
     ],
   },
+  alternates: { canonical: "https://www.brinkdesign.co" },
+  twitter: {
+    card: "summary_large_image",
+    title: "Brink Design Co. - Pro AV & Low Voltage Solutions",
+    description: "Professional low voltage AV installations including security cameras, networking, door access, and more — powered by Brink Design Co.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
 };
 
 

--- a/src/app/network-cabling/page.tsx
+++ b/src/app/network-cabling/page.tsx
@@ -21,6 +21,14 @@ export const metadata: Metadata = {
             },
         ],
     },
+    alternates: { canonical: "https://www.brinkdesign.co/network-cabling" },
+    twitter: {
+        card: "summary_large_image",
+        title: "Network Cabling - Brink Design Co.",
+        description:
+            "Clean and reliable network cabling services in Rapid City. We install structured wiring, racks, patch panels, and Wi-Fi for offices and new builds.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
 };
 
 export default function NetworkCablingPage() {

--- a/src/app/photo-booth-opt-in/page.tsx
+++ b/src/app/photo-booth-opt-in/page.tsx
@@ -19,6 +19,14 @@ export const metadata: Metadata = {
             },
         ],
     },
+    alternates: { canonical: "https://www.brinkdesign.co/photo-booth-opt-in" },
+    twitter: {
+        card: "summary_large_image",
+        title: "Photo Booth Opt-In Policy - Brink Design Co.",
+        description:
+            "Details on how we send your photo booth images via SMS and how to manage your consent and privacy preferences.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
 };
 
 export default function PhotoBoothOptInPolicy() {

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -3,6 +3,13 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Privacy Policy - Brink Design Co.",
   description: "Learn how Brink Design Co. handles your information when providing AV installations, networking, and low voltage services.",
+  alternates: { canonical: "https://www.brinkdesign.co/privacy-policy" },
+  twitter: {
+    card: "summary_large_image",
+    title: "Privacy Policy - Brink Design Co.",
+    description: "Learn how Brink Design Co. handles your information when providing AV installations, networking, and low voltage services.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
 };
 
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -30,6 +30,13 @@ async function fetchProjects() {
 export const metadata: Metadata = {
   title: "Projects - Brink Design Co.",
   description: "Browse our portfolio of AV installations and low voltage projects, including networking, security systems, door access, and more.",
+  alternates: { canonical: "https://www.brinkdesign.co/projects" },
+  twitter: {
+    card: "summary_large_image",
+    title: "Projects - Brink Design Co.",
+    description: "Browse our portfolio of AV installations and low voltage projects, including networking, security systems, door access, and more.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
 };
 
 export default async function Page() {

--- a/src/app/security-installation/page.tsx
+++ b/src/app/security-installation/page.tsx
@@ -21,6 +21,14 @@ export const metadata: Metadata = {
             },
         ],
     },
+    alternates: { canonical: "https://www.brinkdesign.co/security-installation" },
+    twitter: {
+        card: "summary_large_image",
+        title: "Security System Installation - Brink Design Co.",
+        description:
+            "Professional security camera and access control installation in Rapid City. Modern, scalable systems with no monthly fees.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
 };
 
 export default function SecurityInstallationPage() {

--- a/src/app/service-area/page.tsx
+++ b/src/app/service-area/page.tsx
@@ -13,6 +13,13 @@ export const metadata: Metadata = {
         url: "https://www.brinkdesign.co/service-area",
         type: "website",
     },
+    alternates: { canonical: "https://www.brinkdesign.co/service-area" },
+    twitter: {
+        card: "summary_large_image",
+        title: "Service Area - Brink Design Co.",
+        description: "Brink Design Co. provides professional AV and low voltage installations throughout Rapid City and the Black Hills. Explore our coverage area and services.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
 };
 
 

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -36,6 +36,13 @@ const services = [
 export const metadata: Metadata = {
     title: "Low Voltage Services - Brink Design Co.",
     description: "Explore our professional low voltage services including security system installation, network cabling, audio/video solutions, and more.",
+    alternates: { canonical: "https://www.brinkdesign.co/services" },
+    twitter: {
+        card: "summary_large_image",
+        title: "Low Voltage Services - Brink Design Co.",
+        description: "Explore our professional low voltage services including security system installation, network cabling, audio/video solutions, and more.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
 };
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- expand page metadata to include canonical URLs and Twitter card settings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c1c3a5d6c8321b97a828e415c37d3