### PR TITLE
Fix canonical URL for Commercial AV page

### DIFF
--- a/src/app/services/commercial-av/page.tsx
+++ b/src/app/services/commercial-av/page.tsx
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
             },
         ],
     },
-    alternates: { canonical: "https://www.brinkdesign.co/commercial-av" },
+    alternates: { canonical: "https://www.brinkdesign.co/services/commercial-av" },
     twitter: {
         card: "summary_large_image",
         title: "Professional Commercial AV Installation - Brink Design Co.",


### PR DESCRIPTION
## Summary
- fix canonical URL for the commercial AV services page
- verify canonical tags on other pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686224bae48c83218e8cfab5b58ca9af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the canonical URL for the commercial AV services page to improve link accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->