### PR TITLE
Add blog CTA to about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -180,6 +180,10 @@ const AboutPage: React.FC = () => {
                                     See Our Work
                                     <ArrowRight className="w-5 h-5 ml-2" />
                                 </Link>
+                                <Link href="/blog" className="inline-flex items-center justify-center px-8 py-4 border-2 border-white/30 text-white hover:bg-white/10 rounded-xl transition-all duration-300">
+                                    Read Recent Articles
+                                    <ArrowRight className="w-5 h-5 ml-2" />
+                                </Link>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- add a call-to-action linking to the blog on the About page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686224d7d06c8321849788d7d2c1f419