### PR TITLE
Add GA event helpers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import "./globals.css";
 import { cn } from "@/lib/utils";
 import ConditionalLayout from "@/components/ConditionalLayout";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import Analytics from "@/components/Analytics";
+import { GA_ID } from "@/lib/analytics";
 
 export const metadata: Metadata = {
   title: "Brink Design | AV & Low Voltage Tech Installers",
@@ -95,7 +97,8 @@ export default function RootLayout({
         <ConditionalLayout>
           {children}
         </ConditionalLayout>
-        <GoogleAnalytics gaId="G-K6VB75FMGH" />
+        <GoogleAnalytics gaId={GA_ID} />
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { trackPageView } from "@/lib/analytics";
+
+export default function Analytics() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname) {
+      trackPageView(pathname);
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import ReCAPTCHA from "react-google-recaptcha";
 import { User, Mail, MessageSquare, FileText, Send, Loader2 } from 'lucide-react';
+import { trackEvent } from '@/lib/analytics';
 
 interface ContactFormProps {
     onSuccess: (message: string) => void;
@@ -51,6 +52,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSuccess, onError }) => {
 
             if (response.ok) {
                 onSuccess('Message sent successfully! We\'ll get back to you within 24 hours.');
+                trackEvent('contact_form_submitted', { subject: formData.subject });
                 setFormData({
                     name: '',
                     email: '',

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { sendGAEvent } from '@next/third-parties/google';
+
+export const GA_ID = process.env.NEXT_PUBLIC_GA_ID || 'G-K6VB75FMGH';
+
+export function trackPageView(path: string) {
+  if (!GA_ID) return;
+  sendGAEvent('event', 'page_view', {
+    page_path: path,
+  });
+}
+
+export function trackEvent(action: string, params?: Record<string, any>) {
+  if (!GA_ID) return;
+  sendGAEvent('event', action, params);
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -13,5 +13,5 @@ export function trackPageView(path: string) {
 
 export function trackEvent(action: string, params?: Record<string, any>) {
   if (!GA_ID) return;
-  sendGAEvent('event', action, params);
+  sendGAEvent('event', action, params ?? {});
 }


### PR DESCRIPTION
## Summary
- add new analytics utility for Google Analytics
- track page views on route change
- log contact form submits as GA events
- use env GA id in layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686224eb9da883219f3b0ef3010c618d