### PR TITLE
Add analytics tracking for key CTAs

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -23,6 +23,7 @@ import {
     Building,
     Wifi
 } from 'lucide-react';
+import { trackEvent } from '@/lib/analytics';
 
 export const metadata: Metadata = {
     title: "About Brink Design Co. - Rapid City AV & Low Voltage Experts",
@@ -344,7 +345,11 @@ const AboutPage: React.FC = () => {
                                     plus emergency/after-hours service.
                                 </p>
                                 <div className="flex flex-col sm:flex-row gap-4">
-                                    <a href="tel:6053818290" className="inline-flex items-center justify-center px-6 py-3 bg-white text-blue-600 font-bold rounded-lg hover:bg-gray-50 transition-colors">
+                                    <a
+                                        href="tel:6053818290"
+                                        onClick={() => trackEvent('phone_click', { location: 'about-support' })}
+                                        className="inline-flex items-center justify-center px-6 py-3 bg-white text-blue-600 font-bold rounded-lg hover:bg-gray-50 transition-colors"
+                                    >
                                         <Phone className="w-5 h-5 mr-2" />
                                         Call 605-381-8290
                                     </a>
@@ -473,11 +478,19 @@ const AboutPage: React.FC = () => {
                         trust Brink Design Co. for their technology needs.
                     </p>
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                        <Link href="/contact" className="inline-flex items-center justify-center px-8 py-4 bg-white text-orange-600 font-bold rounded-xl hover:bg-gray-50 transition-all duration-300 shadow-lg transform hover:scale-105">
+                        <Link
+                            href="/contact"
+                            onClick={() => trackEvent('start_project_click', { location: 'about' })}
+                            className="inline-flex items-center justify-center px-8 py-4 bg-white text-orange-600 font-bold rounded-xl hover:bg-gray-50 transition-all duration-300 shadow-lg transform hover:scale-105"
+                        >
                             <Users className="w-5 h-5 mr-2" />
                             Start Your Project
                         </Link>
-                        <Link href="tel:6053818290" className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300">
+                        <Link
+                            href="tel:6053818290"
+                            onClick={() => trackEvent('phone_click', { location: 'about' })}
+                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300"
+                        >
                             <Phone className="w-5 h-5 mr-2" />
                             Call (605) 381-8290
                         </Link>

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,5 +1,6 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Mail, Phone, MessageCircle, Clock, Shield, Award, ArrowRight, CheckCircle } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import type { Metadata } from "next";
@@ -170,7 +171,11 @@ export default function FAQPage() {
                                 <MessageCircle className="mr-2" size={20} />
                                 Ask a Question
                             </Link>
-                            <Link href="tel:6053818290" className="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white hover:bg-white/10 rounded-lg transition-all duration-200">
+                            <Link
+                                href="tel:6053818290"
+                                onClick={() => trackEvent('phone_click', { location: 'faq-hero' })}
+                                className="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white hover:bg-white/10 rounded-lg transition-all duration-200"
+                            >
                                 <Phone className="mr-2" size={20} />
                                 Call (605) 381-8290
                             </Link>
@@ -331,7 +336,11 @@ export default function FAQPage() {
                                 <ArrowRight className="w-5 h-5 mx-auto mt-3 group-hover:translate-x-1 transition-transform" />
                             </Link>
                             
-                            <Link href="tel:6053818290" className="group bg-primary text-secondary p-6 rounded-2xl hover:bg-primary/90 transition-all duration-200 hover:shadow-lg">
+                            <Link
+                                href="tel:6053818290"
+                                onClick={() => trackEvent('phone_click', { location: 'faq-bottom' })}
+                                className="group bg-primary text-secondary p-6 rounded-2xl hover:bg-primary/90 transition-all duration-200 hover:shadow-lg"
+                            >
                                 <Phone className="w-8 h-8 mx-auto mb-3 group-hover:scale-110 transition-transform" />
                                 <h3 className="font-bold text-lg mb-2">Call Directly</h3>
                                 <p className="text-sm opacity-80">(605) 381-8290 - Local support</p>

--- a/src/app/linecard/page.tsx
+++ b/src/app/linecard/page.tsx
@@ -4,6 +4,7 @@ import { createReader } from '@keystatic/core/reader';
 import Image from 'next/image';
 import Link from 'next/link';
 import Markdoc from '@markdoc/markdoc';
+import { trackEvent } from '@/lib/analytics';
 import React from 'react';
 
 export default async function LineCardPage() {
@@ -250,7 +251,11 @@ export default async function LineCardPage() {
               Leverage our partnerships with industry leaders to get the highest quality solutions for your project.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/contact" className="inline-flex items-center justify-center px-8 py-4 bg-primary text-secondary font-bold rounded-lg hover:bg-primary/90 transition-all duration-200 hover:shadow-lg">
+              <Link
+                href="/contact"
+                onClick={() => trackEvent('start_project_click', { location: 'linecard' })}
+                className="inline-flex items-center justify-center px-8 py-4 bg-primary text-secondary font-bold rounded-lg hover:bg-primary/90 transition-all duration-200 hover:shadow-lg"
+              >
                 Start Your Project
               </Link>
               <Link href="/services" className="inline-flex items-center justify-center px-8 py-4 border border-primary text-primary hover:bg-primary hover:text-secondary rounded-lg transition-all duration-200">

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import Markdoc from "@markdoc/markdoc";
 import React from 'react';
+import { trackEvent } from '@/lib/analytics';
 
 type Project = {
   slug: string;
@@ -178,7 +179,11 @@ export default async function Project(props: { params: Promise<{ slug: string }>
                 Discover how we delivered exceptional low voltage solutions that transformed this space with cutting-edge technology and professional installation.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 pt-4">
-                <Link href="/contact" className="inline-flex items-center justify-center px-8 py-4 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200 hover:shadow-lg">
+                <Link
+                  href="/contact"
+                  onClick={() => trackEvent('start_project_click', { location: 'project-detail' })}
+                  className="inline-flex items-center justify-center px-8 py-4 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200 hover:shadow-lg"
+                >
                   Start Your Project
                 </Link>
                 <Link href="/projects" className="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white hover:bg-white/10 rounded-lg transition-all duration-200">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ReactElement, JSXElementConstructor, ReactNode, Key } from 'react';
+import { trackEvent } from '@/lib/analytics';
 
 
 const reader = createReader(process.cwd(), keystaticConfig);
@@ -64,7 +65,11 @@ export default async function Page() {
                   Explore our portfolio of successful low voltage installations, from security systems to smart home automation and commercial AV solutions.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4">
-                  <Link href="/contact" className="inline-flex items-center justify-center px-8 py-4 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200 hover:shadow-lg">
+                  <Link
+                    href="/contact"
+                    onClick={() => trackEvent('start_project_click', { location: 'projects-hero' })}
+                    className="inline-flex items-center justify-center px-8 py-4 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200 hover:shadow-lg"
+                  >
                     Start Your Project
                   </Link>
                   <Link href="/services" className="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white hover:bg-white/10 rounded-lg transition-all duration-200">
@@ -169,7 +174,11 @@ export default async function Page() {
               </div>
               <h3 className="text-2xl font-bold text-gray-900 mb-2">No Projects Yet</h3>
               <p className="text-gray-600 mb-6">We&apos;re working on showcasing our amazing projects. Check back soon!</p>
-              <Link href="/contact" className="inline-flex items-center justify-center px-6 py-3 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200">
+              <Link
+                href="/contact"
+                onClick={() => trackEvent('start_project_click', { location: 'projects-empty' })}
+                className="inline-flex items-center justify-center px-6 py-3 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200"
+              >
                 Start Your Project
               </Link>
             </div>

--- a/src/app/service-area/page.tsx
+++ b/src/app/service-area/page.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Phone, Mail } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 import Link from "next/link";
 import { Metadata } from "next";
 
@@ -106,7 +107,11 @@ export default function ServiceArea() {
                             <Link href="/contact" className="inline-flex items-center justify-center px-8 py-4 bg-secondary text-primary font-bold rounded-lg hover:bg-secondary/90 transition-all duration-200 hover:shadow-lg">
                                 Schedule Site Visit
                             </Link>
-                            <Link href="tel:6053818290" className="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white hover:bg-white/10 rounded-lg transition-all duration-200">
+                            <Link
+                                href="tel:6053818290"
+                                onClick={() => trackEvent('phone_click', { location: 'service-area-hero' })}
+                                className="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white hover:bg-white/10 rounded-lg transition-all duration-200"
+                            >
                                 <Phone className="mr-2" size={20} />
                                 Call (605) 381-8290
                             </Link>
@@ -263,7 +268,11 @@ export default function ServiceArea() {
                                 <Mail className="mr-2" size={20} />
                                 Schedule Consultation
                             </Link>
-                            <Link href="tel:6053818290" className="inline-flex items-center justify-center px-8 py-4 border border-primary text-primary hover:bg-primary hover:text-secondary rounded-lg transition-all duration-200">
+                            <Link
+                                href="tel:6053818290"
+                                onClick={() => trackEvent('phone_click', { location: 'service-area-bottom' })}
+                                className="inline-flex items-center justify-center px-8 py-4 border border-primary text-primary hover:bg-primary hover:text-secondary rounded-lg transition-all duration-200"
+                            >
                                 <Phone className="mr-2" size={20} />
                                 Call (605) 381-8290
                             </Link>

--- a/src/app/services/commercial-av/page.tsx
+++ b/src/app/services/commercial-av/page.tsx
@@ -28,6 +28,7 @@ import {
     Wifi,
     Play
 } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 
 export const metadata: Metadata = {
     title: "Professional Commercial AV Installation - Brink Design Co.",
@@ -444,7 +445,11 @@ export default function CommercialAVPage() {
                             <Play className="w-5 h-5 mr-2" />
                             Start Your AV Project Today
                         </Link>
-                        <Link href="tel:+16051234567" className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300">
+                        <Link
+                            href="tel:+16051234567"
+                            onClick={() => trackEvent('phone_click', { location: 'commercial-av' })}
+                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300"
+                        >
                             <Phone className="w-5 h-5 mr-2" />
                             Call (605) 123-4567
                         </Link>

--- a/src/app/services/low-voltage/page.tsx
+++ b/src/app/services/low-voltage/page.tsx
@@ -24,6 +24,7 @@ import {
     Wrench,
     FileCheck
 } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 
 export const metadata: Metadata = {
     title: "Professional Low Voltage Cabling Services - Brink Design Co.",
@@ -361,7 +362,11 @@ export default function LowVoltageCablingPage() {
                             <Zap className="w-5 h-5 mr-2" />
                             Schedule Free Walkthrough
                         </Link>
-                        <Link href="tel:+16051234567" className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300">
+                        <Link
+                            href="tel:+16051234567"
+                            onClick={() => trackEvent('phone_click', { location: 'low-voltage' })}
+                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300"
+                        >
                             <Phone className="w-5 h-5 mr-2" />
                             Call (605) 123-4567
                         </Link>

--- a/src/app/services/security-cameras/page.tsx
+++ b/src/app/services/security-cameras/page.tsx
@@ -27,6 +27,7 @@ import {
     MapPin,
     Search
 } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 
 export const metadata: Metadata = {
     title: "Professional Security Camera Systems - Brink Design Co.",
@@ -428,7 +429,11 @@ export default function SecurityCamerasPage() {
                             <Shield className="w-5 h-5 mr-2" />
                             Get Free Security Assessment
                         </Link>
-                        <Link href="tel:+16051234567" className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300">
+                        <Link
+                            href="tel:+16051234567"
+                            onClick={() => trackEvent('phone_click', { location: 'security-cameras' })}
+                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-orange-600 rounded-xl transition-all duration-300"
+                        >
                             <Phone className="w-5 h-5 mr-2" />
                             Call (605) 123-4567
                         </Link>

--- a/src/components/FeaturedProjectsClient.tsx
+++ b/src/components/FeaturedProjectsClient.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardFooter, CardTitle } from '@/components/ui/card';
 import { ArrowRight, Eye, Calendar, MapPin } from 'lucide-react';
+import { trackEvent } from '@/lib/analytics';
 import React from 'react';
 
 type Project = {
@@ -136,8 +137,9 @@ export default function FeaturedProjectsClient({ projects }: { projects: Project
                 View All Projects
                 <ArrowRight className="w-5 h-5 ml-2" />
               </Link>
-              <Link 
+              <Link
                 href="/contact"
+                onClick={() => trackEvent('start_project_click', { location: 'featured_projects' })}
                 className="inline-flex items-center justify-center px-8 py-4 border-2 border-gray-300 text-gray-700 hover:border-gray-400 hover:text-gray-900 rounded-xl transition-all duration-300"
               >
                 Start Your Project

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import React from 'react';
 import Logo from './logo';
 import Link from 'next/link';
 import { Button } from './ui/button';
+import { trackEvent } from '@/lib/analytics';
 
 const Footer: React.FC = () => {
     return (
@@ -93,7 +96,10 @@ const Footer: React.FC = () => {
                             <div className="bg-white/5 backdrop-blur-sm rounded-lg p-4 border border-white/10">
                                 <p className="text-sm mb-3 text-gray-300 font-medium">Ready to get started?</p>
                                 <p className="text-xs mb-4 text-gray-400">Free consultation • No pressure • Expert advice</p>
-                                <Link href="/contact">
+                                <Link
+                                    href="/contact"
+                                    onClick={() => trackEvent('cta_click', { cta: 'footer_book_site_visit' })}
+                                >
                                     <Button className="w-full bg-secondary hover:bg-secondary/90 text-primary font-semibold transition-all duration-200 hover:shadow-lg hover:shadow-secondary/20">
                                         Book Free Site Visit
                                     </Button>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,6 +5,7 @@ import { Button } from "./ui/button";
 import { usePathname } from 'next/navigation';
 import Logo from "./logo";
 import { Phone, MapPin, Clock, Menu, X, ChevronDown } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 
 export default function Header() {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -164,6 +165,7 @@ export default function Header() {
                         <div className="hidden lg:flex items-center space-x-4">
                             <a
                                 href="tel:6053818290"
+                                onClick={() => trackEvent('phone_click', { location: 'header-desktop' })}
                                 className="flex items-center space-x-2 text-gray-700 hover:text-blue-600 transition-colors duration-200"
                             >
                                 <Phone className="w-4 h-4" />
@@ -200,7 +202,11 @@ export default function Header() {
                             <div className="bg-gray-50 rounded-lg p-4 space-y-3">
                                 <div className="flex items-center space-x-3">
                                     <Phone className="w-5 h-5 text-blue-600" />
-                                    <a href="tel:6053818290" className="text-blue-600 font-semibold text-lg">
+                                    <a
+                                        href="tel:6053818290"
+                                        onClick={() => trackEvent('phone_click', { location: 'header-mobile' })}
+                                        className="text-blue-600 font-semibold text-lg"
+                                    >
                                         (605) 381-8290
                                     </a>
                                 </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button';
 import Link from 'next/link'
 import { motion } from 'framer-motion';
 import { ArrowRight, CheckCircle, Users, Star, Phone } from 'lucide-react';
+import { trackEvent } from '@/lib/analytics';
 
 export default function Hero() {
     return (
@@ -91,13 +92,21 @@ export default function Hero() {
                             className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start"
                         >
                             <Button asChild size="lg" className="bg-yellow-500 text-gray-900 hover:bg-yellow-400 font-bold px-8 py-4 rounded-xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300">
-                                <Link href="/contact" className="inline-flex items-center">
+                                <Link
+                                    href="/contact"
+                                    onClick={() => trackEvent('cta_click', { cta: 'hero_request_free_quote' })}
+                                    className="inline-flex items-center"
+                                >
                                     Request Free Quote
                                     <ArrowRight className="w-5 h-5 ml-2" />
                                 </Link>
                             </Button>
                             <Button asChild variant="outline" size="lg">
-                                <Link href="tel:6053818290" className="inline-flex items-center">
+                                <Link
+                                    href="tel:6053818290"
+                                    onClick={() => trackEvent('phone_click', { location: 'hero' })}
+                                    className="inline-flex items-center"
+                                >
                                     <Phone className="w-5 h-5 mr-2" />
                                     Call (605) 381-8290
                                 </Link>

--- a/src/components/services.tsx
+++ b/src/components/services.tsx
@@ -3,6 +3,7 @@
 import { Network, Shield, Speaker, Home, ArrowRight, CheckCircle } from 'lucide-react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import { trackEvent } from '@/lib/analytics';
 
 const services = [
   {
@@ -81,7 +82,11 @@ export default function Services() {
               viewport={{ once: true }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
             >
-              <Link href={service.href} className="group block h-full">
+              <Link
+                href={service.href}
+                onClick={() => trackEvent('service_learn_more', { service: service.title })}
+                className="group block h-full"
+              >
                 <div className="h-full bg-white rounded-2xl shadow-lg border border-gray-100 p-8 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 group-hover:border-gray-200">
                   {/* Icon */}
                   <div className={`w-16 h-16 bg-gradient-to-r ${service.color} rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300`}>
@@ -142,8 +147,9 @@ export default function Services() {
                 Get Free Consultation
                 <ArrowRight className="w-5 h-5 ml-2" />
               </Link>
-              <Link 
+              <Link
                 href="tel:6053818290"
+                onClick={() => trackEvent('phone_click', { location: 'services' })}
                 className="inline-flex items-center justify-center px-8 py-4 border-2 border-gray-300 text-gray-700 hover:border-gray-400 hover:text-gray-900 rounded-xl transition-all duration-300"
               >
                 Call (605) 381-8290

--- a/src/components/stickyHeaderCTA.tsx
+++ b/src/components/stickyHeaderCTA.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Phone, Calendar, X } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 
 export default function StickyHeaderCTA() {
     const [isVisible, setIsVisible] = useState(false);
@@ -19,6 +20,7 @@ export default function StickyHeaderCTA() {
     }, []);
 
     const handleCallClick = () => {
+        trackEvent('phone_click', { location: 'sticky_header_cta' });
         window.location.href = "tel:+16053818290"; // Replace with your actual phone number
     };
 

--- a/src/components/testimonials-client.tsx
+++ b/src/components/testimonials-client.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { Card, CardContent } from "./ui/card";
 import { motion, AnimatePresence } from "framer-motion";
 import { Quote, Star, ExternalLink, ChevronLeft, ChevronRight } from "lucide-react";
+import { trackEvent } from '@/lib/analytics';
 import Markdoc from "@markdoc/markdoc";
 
 interface Testimonial {
@@ -173,12 +174,14 @@ export default function TestimonialsClient({ testimonials }: TestimonialsClientP
                         <div className="flex flex-col sm:flex-row gap-4 justify-center">
                             <a
                                 href="/contact"
+                                onClick={() => trackEvent('start_project_click', { location: 'testimonials' })}
                                 className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white font-bold rounded-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 shadow-lg"
                             >
                                 Start Your Project
                             </a>
                             <a
                                 href="tel:6053818290"
+                                onClick={() => trackEvent('phone_click', { location: 'testimonials' })}
                                 className="inline-flex items-center justify-center px-8 py-4 border-2 border-gray-300 text-gray-700 hover:border-gray-400 hover:text-gray-900 rounded-xl transition-all duration-300"
                             >
                                 Call (605) 381-8290


### PR DESCRIPTION
## Summary
- add GA event tracking for phone and CTA buttons across the site
- convert footer to client component for event handling
- capture `Start Your Project` and call interactions on pages and components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862aeb180ac832180c6b9ffb9850bd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics event tracking to various interactive links across multiple pages and components, including phone call links, "Start Your Project" links, and call-to-action buttons.
  * User interactions such as clicking phone numbers and project inquiry links are now tracked for improved analytics insights.

* **Chores**
  * Integrated analytics tracking without altering the appearance or navigation of existing elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->