### PR TITLE
Replace hard-coded colors with brand palette

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -78,7 +78,7 @@ const AboutPage: React.FC = () => {
             icon: Shield,
             title: "Clean Installs",
             description: "Neat cable management and professional finishes that last",
-            color: "text-blue-600"
+            color: "text-primary"
         },
         {
             icon: Target,
@@ -90,7 +90,7 @@ const AboutPage: React.FC = () => {
             icon: Award,
             title: "Built to Last",
             description: "Enterprise-grade hardware and industry best practices",
-            color: "text-purple-600"
+            color: "text-primary"
         },
         {
             icon: MapPin,
@@ -108,7 +108,7 @@ const AboutPage: React.FC = () => {
             icon: Zap,
             title: "Fast Response",
             description: "Emergency support and quick turnaround times",
-            color: "text-yellow-500"
+            color: "text-accent"
         }
     ];
 
@@ -253,7 +253,7 @@ const AboutPage: React.FC = () => {
                         <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Mission</h2>
                         <div className="max-w-4xl mx-auto">
                             <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 md:p-12">
-                                <Target className="w-16 h-16 text-blue-600 mx-auto mb-6" />
+                                <Target className="w-16 h-16 text-primary mx-auto mb-6" />
                                 <blockquote className="text-2xl font-medium text-gray-900 mb-6 leading-relaxed">
                                     &ldquo;To empower churches, businesses, ranchers, and homeowners across western
                                     South Dakota (and into Wyoming and Nebraska) with smart, scalable technology&mdash;
@@ -262,7 +262,7 @@ const AboutPage: React.FC = () => {
                                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
                                     <div className="text-center">
                                         <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-2">
-                                            <Users className="w-6 h-6 text-blue-600" />
+                                            <Users className="w-6 h-6 text-primary" />
                                         </div>
                                         <h4 className="font-semibold text-gray-900">People First</h4>
                                         <p className="text-sm text-gray-600">Building lasting relationships with every client</p>
@@ -276,7 +276,7 @@ const AboutPage: React.FC = () => {
                                     </div>
                                     <div className="text-center">
                                         <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-2">
-                                            <MapPin className="w-6 h-6 text-purple-600" />
+                                            <MapPin className="w-6 h-6 text-primary" />
                                         </div>
                                         <h4 className="font-semibold text-gray-900">Local Focus</h4>
                                         <p className="text-sm text-gray-600">Dedicated to serving our South Dakota community</p>
@@ -311,7 +311,7 @@ const AboutPage: React.FC = () => {
                                     <p className="text-gray-700 text-lg leading-relaxed mb-6">
                                         {service.description}
                                     </p>
-                                    <Link href="/contact" className="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium">
+                                    <Link href="/contact" className="inline-flex items-center text-primary hover:text-primary font-medium">
                                         Learn More
                                         <ArrowRight className="w-4 h-4 ml-2" />
                                     </Link>
@@ -344,7 +344,7 @@ const AboutPage: React.FC = () => {
                                     plus emergency/after-hours service.
                                 </p>
                                 <div className="flex flex-col sm:flex-row gap-4">
-                                    <a href="tel:6053818290" className="inline-flex items-center justify-center px-6 py-3 bg-white text-blue-600 font-bold rounded-lg hover:bg-gray-50 transition-colors">
+                                    <a href="tel:6053818290" className="inline-flex items-center justify-center px-6 py-3 bg-white text-primary font-bold rounded-lg hover:bg-gray-50 transition-colors">
                                         <Phone className="w-5 h-5 mr-2" />
                                         Call 605-381-8290
                                     </a>
@@ -405,7 +405,7 @@ const AboutPage: React.FC = () => {
                     />
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
                         <div className="text-center">
-                            <MapPin className="w-8 h-8 text-blue-600 mx-auto mb-2" />
+                            <MapPin className="w-8 h-8 text-primary mx-auto mb-2" />
                             <h4 className="font-semibold text-gray-900">Primary Service Area</h4>
                             <p className="text-sm text-gray-600">Western South Dakota</p>
                         </div>
@@ -415,7 +415,7 @@ const AboutPage: React.FC = () => {
                             <p className="text-sm text-gray-600">Wyoming & Nebraska</p>
                         </div>
                         <div className="text-center">
-                            <Phone className="w-8 h-8 text-purple-600 mx-auto mb-2" />
+                            <Phone className="w-8 h-8 text-primary mx-auto mb-2" />
                             <h4 className="font-semibold text-gray-900">Remote Support</h4>
                             <p className="text-sm text-gray-600">Nationwide assistance</p>
                         </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -82,14 +82,14 @@ export default async function BlogPage() {
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
                         <Link
                             href="/contact"
-                            className="inline-flex items-center justify-center px-8 py-4 bg-white text-blue-600 font-bold rounded-xl hover:bg-gray-50 transition-colors duration-200 shadow-lg"
+                            className="inline-flex items-center justify-center px-8 py-4 bg-white text-primary font-bold rounded-xl hover:bg-gray-50 transition-colors duration-200 shadow-lg"
                         >
                             Get Expert Consultation
                             <ArrowRight className="w-5 h-5 ml-2" />
                         </Link>
                         <Link
                             href="/services"
-                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-blue-600 rounded-xl transition-colors duration-200"
+                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-primary rounded-xl transition-colors duration-200"
                         >
                             Our Services
                         </Link>
@@ -145,7 +145,7 @@ export default async function BlogPage() {
                                                 </div>
 
                                                 {/* Title */}
-                                                <CardTitle className="text-xl font-bold text-gray-900 mb-3 line-clamp-2 group-hover:text-blue-600 transition-colors duration-200">
+                                                <CardTitle className="text-xl font-bold text-gray-900 mb-3 line-clamp-2 group-hover:text-primary transition-colors duration-200">
                                                     {post.entry.title}
                                                 </CardTitle>
 
@@ -155,7 +155,7 @@ export default async function BlogPage() {
                                                 </p>
 
                                                 {/* Read More Link */}
-                                                <div className="flex items-center text-blue-600 font-medium group-hover:text-blue-700 transition-colors duration-200">
+                                                <div className="flex items-center text-primary font-medium group-hover:text-primary transition-colors duration-200">
                                                     <span>Read Article</span>
                                                     <ArrowRight className="w-4 h-4 ml-2 transition-transform duration-200 group-hover:translate-x-1" />
                                                 </div>
@@ -179,7 +179,7 @@ export default async function BlogPage() {
                             </p>
                             <Link
                                 href="/contact"
-                                className="inline-flex items-center justify-center px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors duration-200"
+                                className="inline-flex items-center justify-center px-6 py-3 bg-primary text-white font-semibold rounded-lg hover:bg-primary/90 transition-colors duration-200"
                             >
                                 Get Expert Advice Now
                                 <ArrowRight className="w-4 h-4 ml-2" />
@@ -202,14 +202,14 @@ export default async function BlogPage() {
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
                         <Link
                             href="/contact"
-                            className="inline-flex items-center justify-center px-8 py-4 bg-white text-blue-600 font-bold rounded-xl hover:bg-gray-50 transition-colors duration-200 shadow-lg"
+                            className="inline-flex items-center justify-center px-8 py-4 bg-white text-primary font-bold rounded-xl hover:bg-gray-50 transition-colors duration-200 shadow-lg"
                         >
                             Schedule Consultation
                             <ArrowRight className="w-5 h-5 ml-2" />
                         </Link>
                         <Link
                             href="/projects"
-                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-blue-600 rounded-xl transition-colors duration-200"
+                            className="inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-primary rounded-xl transition-colors duration-200"
                         >
                             View Our Work
                         </Link>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -44,7 +44,7 @@ export default function PrivacyPolicy() {
                 {/* Introduction */}
                 <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
                     <h2 className="text-2xl font-bold text-gray-900 mb-4 flex items-center">
-                        <Shield className="w-6 h-6 mr-3 text-blue-600" />
+                        <Shield className="w-6 h-6 mr-3 text-primary" />
                         Our Commitment to Your Privacy
                     </h2>
                     <p className="text-gray-700 leading-relaxed">
@@ -59,7 +59,7 @@ export default function PrivacyPolicy() {
                 {/* Information We Collect */}
                 <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
                     <h2 className="text-2xl font-bold text-gray-900 mb-6 flex items-center">
-                        <Eye className="w-6 h-6 mr-3 text-blue-600" />
+                        <Eye className="w-6 h-6 mr-3 text-primary" />
                         1. Information We Collect
                     </h2>
                     <p className="mb-4 text-gray-700 leading-relaxed">
@@ -80,11 +80,11 @@ export default function PrivacyPolicy() {
                             </ul>
                         </div>
                         <div className="bg-purple-50 rounded-lg p-4 border border-purple-200">
-                            <h4 className="font-semibold text-purple-900 mb-2 flex items-center">
+                            <h4 className="font-semibold text-primary mb-2 flex items-center">
                                 <Eye className="w-4 h-4 mr-2" />
                                 Information We Collect Automatically:
                             </h4>
-                            <ul className="space-y-1 text-sm text-purple-800">
+                            <ul className="space-y-1 text-sm text-primary">
                                 <li className="flex items-start"><CheckCircle className="w-3 h-3 mr-2 mt-1 flex-shrink-0" />Usage data: Information about how you interact with our websites, apps, or games, including IP address, browser type, device identifiers, and other similar data.</li>
                                 <li className="flex items-start"><CheckCircle className="w-3 h-3 mr-2 mt-1 flex-shrink-0" />Cookies and tracking technologies: We use cookies, web beacons, and similar technologies to collect data about your usage patterns.</li>
                             </ul>
@@ -95,7 +95,7 @@ export default function PrivacyPolicy() {
                 {/* How We Use Your Information */}
                 <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
                     <h2 className="text-2xl font-bold text-gray-900 mb-6 flex items-center">
-                        <Shield className="w-6 h-6 mr-3 text-blue-600" />
+                        <Shield className="w-6 h-6 mr-3 text-primary" />
                         2. How We Use Your Information
                     </h2>
                     <p className="mb-4 text-gray-700 leading-relaxed">We may use your information for purposes such as:</p>
@@ -109,8 +109,8 @@ export default function PrivacyPolicy() {
                         </div>
                         <div className="bg-blue-50 rounded-lg p-4 border border-blue-200">
                             <ul className="space-y-2 text-sm text-blue-800">
-                                <li className="flex items-start"><CheckCircle className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0 text-blue-600" /><span><strong>Communications:</strong> To send you updates, marketing communications, or information about our Services.</span></li>
-                                <li className="flex items-start"><CheckCircle className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0 text-blue-600" /><span><strong>Legal and compliance:</strong> To comply with legal obligations and protect the rights of Brink Design.</span></li>
+                                <li className="flex items-start"><CheckCircle className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0 text-primary" /><span><strong>Communications:</strong> To send you updates, marketing communications, or information about our Services.</span></li>
+                                <li className="flex items-start"><CheckCircle className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0 text-primary" /><span><strong>Legal and compliance:</strong> To comply with legal obligations and protect the rights of Brink Design.</span></li>
                             </ul>
                         </div>
                     </div>
@@ -119,13 +119,13 @@ export default function PrivacyPolicy() {
                 {/* How We Share Your Information */}
                 <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
                     <h2 className="text-2xl font-bold text-gray-900 mb-6 flex items-center">
-                        <Lock className="w-6 h-6 mr-3 text-blue-600" />
+                        <Lock className="w-6 h-6 mr-3 text-primary" />
                         3. How We Share Your Information
                     </h2>
                     <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4">
                         <div className="flex items-center mb-2">
-                            <AlertTriangle className="w-5 h-5 text-yellow-600 mr-2" />
-                            <p className="font-semibold text-yellow-800">We do not sell or rent your personal information.</p>
+                            <AlertTriangle className="w-5 h-5 text-accent mr-2" />
+                            <p className="font-semibold text-accent">We do not sell or rent your personal information.</p>
                         </div>
                     </div>
                     <p className="mb-4 text-gray-700">We may share your information with:</p>
@@ -168,14 +168,14 @@ export default function PrivacyPolicy() {
                             <p className="text-sm text-green-800">You may access and update your account information.</p>
                         </div>
                         <div className="bg-blue-50 rounded-lg p-4 border border-blue-200 text-center">
-                            <Mail className="w-8 h-8 text-blue-600 mx-auto mb-2" />
+                            <Mail className="w-8 h-8 text-primary mx-auto mb-2" />
                             <h4 className="font-semibold text-blue-900 mb-1">Marketing Opt-out</h4>
                             <p className="text-sm text-blue-800">You can opt out of receiving marketing communications at any time.</p>
                         </div>
                         <div className="bg-purple-50 rounded-lg p-4 border border-purple-200 text-center">
-                            <Shield className="w-8 h-8 text-purple-600 mx-auto mb-2" />
-                            <h4 className="font-semibold text-purple-900 mb-1">Cookie Settings</h4>
-                            <p className="text-sm text-purple-800">Most web browsers allow you to manage cookie settings.</p>
+                            <Shield className="w-8 h-8 text-primary mx-auto mb-2" />
+                            <h4 className="font-semibold text-primary mb-1">Cookie Settings</h4>
+                            <p className="text-sm text-primary">Most web browsers allow you to manage cookie settings.</p>
                         </div>
                     </div>
                 </div>
@@ -209,7 +209,7 @@ export default function PrivacyPolicy() {
                 {/* Changes to Policy */}
                 <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
                     <h2 className="text-2xl font-bold text-gray-900 mb-6 flex items-center">
-                        <FileText className="w-6 h-6 mr-3 text-purple-600" />
+                        <FileText className="w-6 h-6 mr-3 text-primary" />
                         7. Changes to This Privacy Policy
                     </h2>
                     <p className="text-gray-700 leading-relaxed">

--- a/src/app/services/commercial-av/page.tsx
+++ b/src/app/services/commercial-av/page.tsx
@@ -130,13 +130,13 @@ export default function CommercialAVPage() {
             icon: Award,
             title: "Expert Design & Engineering",
             description: "Custom AV solutions designed specifically for your space and needs",
-            color: "text-purple-600"
+            color: "text-primary"
         },
         {
             icon: Settings,
             title: "Professional Installation",
             description: "Clean, organized installations with proper cable management",
-            color: "text-blue-600"
+            color: "text-primary"
         },
         {
             icon: Clock,
@@ -154,7 +154,7 @@ export default function CommercialAVPage() {
             icon: Star,
             title: "Local Expertise",
             description: "South Dakota based with deep understanding of local needs",
-            color: "text-yellow-500"
+            color: "text-accent"
         },
         {
             icon: Zap,

--- a/src/app/services/low-voltage/page.tsx
+++ b/src/app/services/low-voltage/page.tsx
@@ -95,7 +95,7 @@ export default function LowVoltageCablingPage() {
             icon: FileCheck,
             title: "Testing & Certification",
             description: "Every cable tested and certified to industry standards",
-            color: "text-blue-600"
+            color: "text-primary"
         },
         {
             icon: Clock,
@@ -107,7 +107,7 @@ export default function LowVoltageCablingPage() {
             icon: Users,
             title: "Experienced Team",
             description: "Certified technicians with years of low voltage expertise",
-            color: "text-purple-600"
+            color: "text-primary"
         },
         {
             icon: Award,
@@ -119,7 +119,7 @@ export default function LowVoltageCablingPage() {
             icon: Star,
             title: "Local Expertise",
             description: "South Dakota owned with deep understanding of local needs",
-            color: "text-yellow-500"
+            color: "text-accent"
         }
     ];
 

--- a/src/app/services/security-cameras/page.tsx
+++ b/src/app/services/security-cameras/page.tsx
@@ -125,7 +125,7 @@ export default function SecurityCamerasPage() {
             icon: Lock,
             title: "Secure Systems",
             description: "Enterprise-grade security with encrypted connections and access controls",
-            color: "text-blue-600"
+            color: "text-primary"
         },
         {
             icon: Clock,
@@ -137,7 +137,7 @@ export default function SecurityCamerasPage() {
             icon: Users,
             title: "Local Support",
             description: "South Dakota based team providing ongoing support and service",
-            color: "text-purple-600"
+            color: "text-primary"
         },
         {
             icon: Award,
@@ -149,7 +149,7 @@ export default function SecurityCamerasPage() {
             icon: Star,
             title: "Custom Solutions",
             description: "Tailored systems designed specifically for your property and needs",
-            color: "text-yellow-500"
+            color: "text-accent"
         }
     ];
 

--- a/src/components/FeaturedProjectsClient.tsx
+++ b/src/components/FeaturedProjectsClient.tsx
@@ -71,7 +71,7 @@ export default function FeaturedProjectsClient({ projects }: { projects: Project
                     </div>
                     
                     {/* Bottom Badge */}
-                    <div className="absolute bottom-4 left-4 bg-blue-600/90 backdrop-blur-sm px-3 py-1 rounded-full text-sm font-medium text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="absolute bottom-4 left-4 bg-primary/90 backdrop-blur-sm px-3 py-1 rounded-full text-sm font-medium text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                       Case Study
                     </div>
                   </CardContent>
@@ -80,7 +80,7 @@ export default function FeaturedProjectsClient({ projects }: { projects: Project
                 {/* Content */}
                 <div className="flex-1 flex flex-col">
                   <CardHeader className="pb-3">
-                    <CardTitle className="text-xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors duration-200 line-clamp-2">
+                    <CardTitle className="text-xl font-bold text-gray-900 group-hover:text-primary transition-colors duration-200 line-clamp-2">
                       {project.entry.title}
                     </CardTitle>
                   </CardHeader>
@@ -95,7 +95,7 @@ export default function FeaturedProjectsClient({ projects }: { projects: Project
                     <div className="flex items-center justify-between w-full">
                       <Link 
                         href={`/projects/${project.slug}`}
-                        className="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium text-sm hover:underline"
+                        className="inline-flex items-center text-primary hover:text-primary font-medium text-sm hover:underline"
                       >
                         Read More
                         <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform duration-200" />
@@ -131,7 +131,7 @@ export default function FeaturedProjectsClient({ projects }: { projects: Project
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link 
                 href="/projects"
-                className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white font-bold rounded-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 shadow-lg"
+                className="inline-flex items-center justify-center px-8 py-4 bg-primary text-white font-bold rounded-xl hover:bg-primary/90 transition-all duration-300 transform hover:scale-105 shadow-lg"
               >
                 View All Projects
                 <ArrowRight className="w-5 h-5 ml-2" />

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -45,7 +45,7 @@ export default async function About() {
                         </div>
 
                         <div className="flex flex-col sm:flex-row gap-4">
-                            <Button asChild size="lg" className="bg-yellow-500 text-gray-900 hover:bg-yellow-400 font-bold px-8 py-4 rounded-xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300">
+                            <Button asChild size="lg" className="bg-accent text-gray-900 hover:bg-accent font-bold px-8 py-4 rounded-xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300">
                                 <Link href="/about" className="inline-flex items-center">
                                     Learn Our Story
                                     <ArrowRight className="w-5 h-5 ml-2" />
@@ -67,7 +67,7 @@ export default async function About() {
                             <h3 className="text-2xl font-bold mb-6">Why South Dakota Trusts Us</h3>
                             <div className="space-y-4">
                                 <div className="flex items-center">
-                                    <Award className="w-6 h-6 mr-4 text-yellow-400" />
+                                    <Award className="w-6 h-6 mr-4 text-accent" />
                                     <div>
                                         <div className="font-semibold">Professional Quality</div>
                                         <div className="text-sm text-blue-100">Enterprise-grade installations</div>
@@ -93,7 +93,7 @@ export default async function About() {
                         {/* Stats */}
                         <div className="grid grid-cols-2 gap-4">
                             <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6 text-center border border-white/20">
-                                <div className="text-3xl font-bold text-yellow-400 mb-2">10+</div>
+                                <div className="text-3xl font-bold text-accent mb-2">10+</div>
                                 <div className="text-sm text-blue-100">Years Experience</div>
                             </div>
                             <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6 text-center border border-white/20">

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -72,10 +72,10 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSuccess, onError }) => {
 
     const inputClasses = (fieldName: string) => `
         w-full px-4 py-3 pl-12 bg-white border-2 border-gray-200 rounded-xl
-        focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 
+        focus:border-primary focus:ring-4 focus:ring-primary/10 
         transition-all duration-300 ease-in-out
         placeholder-gray-400 text-gray-900
-        ${focusedField === fieldName ? 'border-blue-500 shadow-lg' : 'hover:border-gray-300'}
+        ${focusedField === fieldName ? 'border-primary shadow-lg' : 'hover:border-gray-300'}
     `;
 
     const labelClasses = "block text-sm font-semibold text-gray-700 mb-2";
@@ -89,7 +89,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSuccess, onError }) => {
                 </label>
                 <div className="relative">
                     <User className={`absolute left-4 top-3.5 w-5 h-5 transition-colors duration-300 ${
-                        focusedField === 'name' ? 'text-blue-500' : 'text-gray-400'
+                        focusedField === 'name' ? 'text-primary' : 'text-gray-400'
                     }`} />
                     <input
                         className={inputClasses('name')}
@@ -112,7 +112,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSuccess, onError }) => {
                 </label>
                 <div className="relative">
                     <Mail className={`absolute left-4 top-3.5 w-5 h-5 transition-colors duration-300 ${
-                        focusedField === 'email' ? 'text-blue-500' : 'text-gray-400'
+                        focusedField === 'email' ? 'text-primary' : 'text-gray-400'
                     }`} />
                     <input
                         className={inputClasses('email')}
@@ -135,7 +135,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSuccess, onError }) => {
                 </label>
                 <div className="relative">
                     <FileText className={`absolute left-4 top-3.5 w-5 h-5 transition-colors duration-300 ${
-                        focusedField === 'subject' ? 'text-blue-500' : 'text-gray-400'
+                        focusedField === 'subject' ? 'text-primary' : 'text-gray-400'
                     }`} />
                     <select
                         className={inputClasses('subject')}
@@ -166,7 +166,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSuccess, onError }) => {
                 </label>
                 <div className="relative">
                     <MessageSquare className={`absolute left-4 top-3.5 w-5 h-5 transition-colors duration-300 ${
-                        focusedField === 'message' ? 'text-blue-500' : 'text-gray-400'
+                        focusedField === 'message' ? 'text-primary' : 'text-gray-400'
                     }`} />
                     <textarea
                         className={`${inputClasses('message')} min-h-[120px] resize-y`}

--- a/src/components/contact_container.tsx
+++ b/src/components/contact_container.tsx
@@ -28,7 +28,7 @@ const ContactContainer = () => {
             description: "Speak directly with our team",
             value: "(605) 381-8290",
             href: "tel:+16053818290",
-            color: "bg-blue-500"
+            color: "bg-primary"
         },
         {
             icon: Mail,
@@ -36,7 +36,7 @@ const ContactContainer = () => {
             description: "Send us a detailed message",
             value: "contact@brinkdesign.co",
             href: "mailto:contact@brinkdesign.co",
-            color: "bg-green-500"
+            color: "bg-primary"
         }
     ];
 
@@ -45,31 +45,31 @@ const ContactContainer = () => {
             icon: ShieldCheck,
             title: "No Hidden Fees",
             description: "Transparent pricing, no subscriptions",
-            color: "text-green-600"
+            color: "text-accent"
         },
         {
             icon: Home,
             title: "Local Experts",
             description: "South Dakota owned & operated",
-            color: "text-blue-600"
+            color: "text-accent"
         },
         {
             icon: Star,
             title: "5-Star Rated",
             description: "Trusted by satisfied clients",
-            color: "text-yellow-500"
+            color: "text-accent"
         },
         {
             icon: Zap,
             title: "Fast Response",
             description: "Same-day replies guaranteed",
-            color: "text-orange-500"
+            color: "text-accent"
         },
         {
             icon: Award,
             title: "Expert Team",
             description: "Certified professionals",
-            color: "text-indigo-600"
+            color: "text-accent"
         }
     ];
 
@@ -111,7 +111,7 @@ const ContactContainer = () => {
                                 </div>
                                 <h3 className="text-xl font-semibold text-gray-900 mb-2">{method.title}</h3>
                                 <p className="text-gray-600 text-sm mb-3">{method.description}</p>
-                                <p className="text-blue-600 font-medium group-hover:text-blue-700 transition-colors">
+                                <p className="text-accent font-medium group-hover:text-accent transition-colors">
                                     {method.value}
                                 </p>
                             </div>
@@ -138,7 +138,7 @@ const ContactContainer = () => {
                                 {/* Feedback Messages */}
                                 {successMessage && (
                                     <div className="mt-6 p-4 bg-green-50 border border-green-200 rounded-xl flex items-center gap-3 animate-in slide-in-from-top duration-300">
-                                        <CheckCircle className="w-5 h-5 text-green-600 flex-shrink-0" />
+                                        <CheckCircle className="w-5 h-5 text-accent flex-shrink-0" />
                                         <span className="text-green-800 font-medium">{successMessage}</span>
                                     </div>
                                 )}
@@ -157,7 +157,7 @@ const ContactContainer = () => {
                         {/* Business Hours */}
                         <div className="bg-white rounded-2xl shadow-lg p-6 mb-8 border border-gray-100">
                             <div className="flex items-center gap-3 mb-4">
-                                <Clock className="w-6 h-6 text-blue-600" />
+                                <Clock className="w-6 h-6 text-accent" />
                                 <h3 className="text-lg font-semibold text-gray-900">Business Hours</h3>
                             </div>
                             <div className="space-y-2 text-sm">
@@ -184,7 +184,7 @@ const ContactContainer = () => {
                         {/* Service Areas */}
                         <div className="bg-white rounded-2xl shadow-lg p-6 border border-gray-100">
                             <div className="flex items-center gap-3 mb-4">
-                                <MapPin className="w-6 h-6 text-purple-600" />
+                                <MapPin className="w-6 h-6 text-primary" />
                                 <h3 className="text-lg font-semibold text-gray-900">Service Areas</h3>
                             </div>
                             <div className="space-y-2 text-sm text-gray-600">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -99,7 +99,7 @@ export default function Header() {
                         <div className="hidden lg:flex items-center space-x-8">
                             <Link 
                                 href="/about" 
-                                className="text-gray-700 hover:text-blue-600 font-medium transition-colors duration-200"
+                                className="text-gray-700 hover:text-primary font-medium transition-colors duration-200"
                             >
                                 About
                             </Link>
@@ -110,7 +110,7 @@ export default function Header() {
                                 onMouseEnter={() => setIsServicesOpen(true)}
                                 onMouseLeave={() => setIsServicesOpen(false)}
                             >
-                                <button className="flex items-center space-x-1 text-gray-700 hover:text-blue-600 font-medium transition-colors duration-200">
+                                <button className="flex items-center space-x-1 text-gray-700 hover:text-primary font-medium transition-colors duration-200">
                                     <span>Services</span>
                                     <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isServicesOpen ? 'rotate-180' : ''}`} />
                                 </button>
@@ -122,14 +122,14 @@ export default function Header() {
                                                 <Link
                                                     key={service.href}
                                                     href={service.href}
-                                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-md transition-colors duration-200"
+                                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-md transition-colors duration-200"
                                                 >
                                                     {service.label}
                                                 </Link>
                                             ))}
                                             <Link
                                                 href="/services"
-                                                className="block px-4 py-3 text-blue-600 font-medium hover:bg-gray-50 rounded-md transition-colors duration-200 border-t border-gray-100 mt-2"
+                                                className="block px-4 py-3 text-primary font-medium hover:bg-gray-50 rounded-md transition-colors duration-200 border-t border-gray-100 mt-2"
                                             >
                                                 View All Services →
                                             </Link>
@@ -140,21 +140,21 @@ export default function Header() {
 
                             <Link 
                                 href="/projects" 
-                                className="text-gray-700 hover:text-blue-600 font-medium transition-colors duration-200"
+                                className="text-gray-700 hover:text-primary font-medium transition-colors duration-200"
                             >
                                 Projects
                             </Link>
                             
                             <Link 
                                 href="/blog" 
-                                className="text-gray-700 hover:text-blue-600 font-medium transition-colors duration-200"
+                                className="text-gray-700 hover:text-primary font-medium transition-colors duration-200"
                             >
                                 Blog
                             </Link>
                             
                             <Link 
                                 href="/linecard" 
-                                className="text-gray-700 hover:text-blue-600 font-medium transition-colors duration-200"
+                                className="text-gray-700 hover:text-primary font-medium transition-colors duration-200"
                             >
                                 Line Card
                             </Link>
@@ -164,7 +164,7 @@ export default function Header() {
                         <div className="hidden lg:flex items-center space-x-4">
                             <a
                                 href="tel:6053818290"
-                                className="flex items-center space-x-2 text-gray-700 hover:text-blue-600 transition-colors duration-200"
+                                className="flex items-center space-x-2 text-gray-700 hover:text-primary transition-colors duration-200"
                             >
                                 <Phone className="w-4 h-4" />
                                 <span className="font-medium">(605) 381-8290</span>
@@ -180,7 +180,7 @@ export default function Header() {
                                 e.stopPropagation();
                                 toggleMobileMenu();
                             }}
-                            className="lg:hidden p-2 rounded-lg text-gray-700 hover:text-blue-600 hover:bg-gray-100 transition-colors duration-200"
+                            className="lg:hidden p-2 rounded-lg text-gray-700 hover:text-primary hover:bg-gray-100 transition-colors duration-200"
                             aria-label="Toggle mobile menu"
                         >
                             {isMobileMenuOpen ? (
@@ -199,13 +199,13 @@ export default function Header() {
                             {/* Mobile Contact Info */}
                             <div className="bg-gray-50 rounded-lg p-4 space-y-3">
                                 <div className="flex items-center space-x-3">
-                                    <Phone className="w-5 h-5 text-blue-600" />
-                                    <a href="tel:6053818290" className="text-blue-600 font-semibold text-lg">
+                                    <Phone className="w-5 h-5 text-primary" />
+                                    <a href="tel:6053818290" className="text-primary font-semibold text-lg">
                                         (605) 381-8290
                                     </a>
                                 </div>
                                 <div className="flex items-center space-x-3">
-                                    <MapPin className="w-5 h-5 text-blue-600" />
+                                    <MapPin className="w-5 h-5 text-primary" />
                                     <span className="text-gray-700">Serving South Dakota</span>
                                 </div>
                             </div>
@@ -214,7 +214,7 @@ export default function Header() {
                             <nav className="space-y-2">
                                 <Link 
                                     href="/about" 
-                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
+                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
                                     onClick={() => setIsMobileMenuOpen(false)}
                                 >
                                     About
@@ -228,7 +228,7 @@ export default function Header() {
                                         <Link
                                             key={service.href}
                                             href={service.href}
-                                            className="block px-6 py-2 text-gray-600 hover:text-blue-600 hover:bg-gray-50 rounded-lg transition-colors duration-200"
+                                            className="block px-6 py-2 text-gray-600 hover:text-primary hover:bg-gray-50 rounded-lg transition-colors duration-200"
                                             onClick={() => setIsMobileMenuOpen(false)}
                                         >
                                             {service.label}
@@ -236,7 +236,7 @@ export default function Header() {
                                     ))}
                                     <Link
                                         href="/services"
-                                        className="block px-6 py-2 text-blue-600 font-medium hover:bg-gray-50 rounded-lg transition-colors duration-200"
+                                        className="block px-6 py-2 text-primary font-medium hover:bg-gray-50 rounded-lg transition-colors duration-200"
                                         onClick={() => setIsMobileMenuOpen(false)}
                                     >
                                         View All Services →
@@ -245,7 +245,7 @@ export default function Header() {
                                 
                                 <Link 
                                     href="/projects" 
-                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
+                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
                                     onClick={() => setIsMobileMenuOpen(false)}
                                 >
                                     Projects
@@ -253,7 +253,7 @@ export default function Header() {
                                 
                                 <Link 
                                     href="/blog" 
-                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
+                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
                                     onClick={() => setIsMobileMenuOpen(false)}
                                 >
                                     Blog
@@ -261,7 +261,7 @@ export default function Header() {
                                 
                                 <Link 
                                     href="/linecard" 
-                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
+                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
                                     onClick={() => setIsMobileMenuOpen(false)}
                                 >
                                     Line Card
@@ -269,7 +269,7 @@ export default function Header() {
                                 
                                 <Link 
                                     href="/service-area" 
-                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
+                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
                                     onClick={() => setIsMobileMenuOpen(false)}
                                 >
                                     Service Area
@@ -277,7 +277,7 @@ export default function Header() {
                                 
                                 <Link 
                                     href="/faq" 
-                                    className="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
+                                    className="block px-4 py-3 text-gray-700 hover:text-primary hover:bg-gray-50 rounded-lg font-medium transition-colors duration-200"
                                     onClick={() => setIsMobileMenuOpen(false)}
                                 >
                                     FAQ
@@ -286,7 +286,7 @@ export default function Header() {
 
                             {/* Mobile CTA */}
                             <div className="pt-4 border-t border-gray-200">
-                                <Button asChild className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 rounded-lg shadow-sm">
+                                <Button asChild className="w-full bg-primary hover:bg-primary/90 text-white font-semibold py-3 rounded-lg shadow-sm">
                                     <Link href="/contact" onClick={() => setIsMobileMenuOpen(false)}>
                                         Schedule Free Site Visit
                                     </Link>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -21,13 +21,13 @@ export default function Hero() {
                     <div className="text-center lg:text-left">
                         {/* Trust Badge */}
                         <div className="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-lg text-sm font-medium mb-6 border border-white/20">
-                            <Star className="w-4 h-4 text-yellow-400 mr-2" />
+                            <Star className="w-4 h-4 text-accent mr-2" />
                             <span className="text-white">10+ Years Serving South Dakota</span>
                         </div>
                         
                         <h1 className='text-4xl md:text-5xl lg:text-6xl font-bold mb-6 text-white leading-tight'>
                             Professional AV, Security & 
-                            <span className="text-yellow-400 block">
+                            <span className="text-accent block">
                                 Low Voltage Solutions
                             </span>
                         </h1>
@@ -54,7 +54,7 @@ export default function Hero() {
                         
                         {/* CTA Buttons */}
                         <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
-                            <Button asChild size="lg" className="bg-yellow-500 text-gray-900 hover:bg-yellow-400 font-bold px-8 py-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-200">
+                            <Button asChild size="lg" className="bg-accent text-gray-900 hover:bg-accent font-bold px-8 py-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-200">
                                 <Link href="/contact" className="inline-flex items-center">
                                     Request Free Quote
                                     <ArrowRight className="w-5 h-5 ml-2" />
@@ -77,7 +77,7 @@ export default function Hero() {
                                 <h3 className="text-2xl font-bold text-white mb-4">Why Choose Brink Design?</h3>
                                 <div className="space-y-4">
                                     <div className="flex items-center text-blue-100">
-                                        <Users className="w-5 h-5 mr-3 text-yellow-400" />
+                                        <Users className="w-5 h-5 mr-3 text-accent" />
                                         <span>Personal service from our local team</span>
                                     </div>
                                     <div className="flex items-center text-blue-100">
@@ -85,7 +85,7 @@ export default function Hero() {
                                         <span>Enterprise-grade equipment & installations</span>
                                     </div>
                                     <div className="flex items-center text-blue-100">
-                                        <Star className="w-5 h-5 mr-3 text-yellow-400" />
+                                        <Star className="w-5 h-5 mr-3 text-accent" />
                                         <span>Honest pricing, no hidden fees</span>
                                     </div>
                                 </div>
@@ -94,7 +94,7 @@ export default function Hero() {
                             {/* Stats Grid */}
                             <div className="grid grid-cols-2 gap-4">
                                 <div className="bg-white/10 backdrop-blur-sm rounded-lg p-4 text-center border border-white/20">
-                                    <div className="text-2xl font-bold text-yellow-400">10+</div>
+                                    <div className="text-2xl font-bold text-accent">10+</div>
                                     <div className="text-sm text-blue-100">Years Experience</div>
                                 </div>
                                 <div className="bg-white/10 backdrop-blur-sm rounded-lg p-4 text-center border border-white/20">

--- a/src/components/services.tsx
+++ b/src/components/services.tsx
@@ -13,7 +13,7 @@ const services = [
     href: '/services/low-voltage',
     color: 'from-blue-500 to-cyan-500',
     bgColor: 'bg-blue-50',
-    textColor: 'text-blue-600'
+    textColor: 'text-primary'
   },
   {
     icon: Shield,
@@ -23,7 +23,7 @@ const services = [
     href: '/services/security-cameras',
     color: 'from-red-500 to-orange-500',
     bgColor: 'bg-red-50',
-    textColor: 'text-red-600'
+    textColor: 'text-primary'
   },
   {
     icon: Speaker,
@@ -33,7 +33,7 @@ const services = [
     href: '/services/commercial-av',
     color: 'from-purple-500 to-pink-500',
     bgColor: 'bg-purple-50',
-    textColor: 'text-purple-600'
+    textColor: 'text-primary'
   },
   {
     icon: Home,
@@ -43,7 +43,7 @@ const services = [
     href: '/contact',
     color: 'from-green-500 to-emerald-500',
     bgColor: 'bg-green-50',
-    textColor: 'text-green-600'
+    textColor: 'text-primary'
   },
 ];
 
@@ -108,7 +108,7 @@ export default function Services() {
                   </div>
 
                   {/* CTA */}
-                  <div className="flex items-center text-sm font-medium text-blue-600 group-hover:text-blue-700 transition-colors">
+                  <div className="flex items-center text-sm font-medium text-primary group-hover:text-primary transition-colors">
                     Learn More
                     <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform duration-200" />
                   </div>

--- a/src/components/testimonials-client.tsx
+++ b/src/components/testimonials-client.tsx
@@ -110,7 +110,7 @@ export default function TestimonialsClient({ testimonials }: TestimonialsClientP
                                 <button
                                     key={i}
                                     className={`w-3 h-3 rounded-full transition-all duration-200 ${
-                                        i === currentIndex ? "bg-blue-600 w-8" : "bg-gray-300 hover:bg-gray-400"
+                                        i === currentIndex ? "bg-primary w-8" : "bg-gray-300 hover:bg-gray-400"
                                     }`}
                                     onClick={() => goToIndex(i)}
                                     aria-label={`Show testimonial ${i + 1}`}
@@ -173,7 +173,7 @@ export default function TestimonialsClient({ testimonials }: TestimonialsClientP
                         <div className="flex flex-col sm:flex-row gap-4 justify-center">
                             <a
                                 href="/contact"
-                                className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white font-bold rounded-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 shadow-lg"
+                                className="inline-flex items-center justify-center px-8 py-4 bg-primary text-white font-bold rounded-xl hover:bg-primary/90 transition-all duration-300 transform hover:scale-105 shadow-lg"
                             >
                                 Start Your Project
                             </a>
@@ -204,7 +204,7 @@ function TestimonialCard({ testimonial, index }: { testimonial: Testimonial; ind
             <Card className="h-full bg-white border border-gray-200 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 group relative overflow-hidden">
                 {/* Quote Icon */}
                 <div className="absolute top-6 right-6 opacity-10 group-hover:opacity-20 transition-opacity duration-300">
-                    <Quote className="w-12 h-12 text-blue-600" />
+                    <Quote className="w-12 h-12 text-primary" />
                 </div>
 
                 <div className="p-6 h-full flex flex-col">
@@ -236,7 +236,7 @@ function TestimonialCard({ testimonial, index }: { testimonial: Testimonial; ind
                                         key={i}
                                         className={`w-4 h-4 ${
                                             i < testimonial.rating
-                                                ? "text-yellow-400 fill-current"
+                                                ? "text-accent fill-current"
                                                 : "text-gray-300"
                                         }`}
                                     />
@@ -260,7 +260,7 @@ function TestimonialCard({ testimonial, index }: { testimonial: Testimonial; ind
                                 href={testimonial.website}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="inline-flex items-center text-blue-600 hover:text-blue-700 text-sm font-medium transition-colors duration-200"
+                                className="inline-flex items-center text-primary hover:text-primary text-sm font-medium transition-colors duration-200"
                             >
                                 Visit Website
                                 <ExternalLink className="w-3 h-3 ml-1" />


### PR DESCRIPTION
## Summary
- refactor hero to use brand accent colors
- standardize header hover and button colors
- update contact components to use brand colors
- replace color utilities in various pages and components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686574134ba48321aaaf049f84351fd7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified color scheme across all pages and components by replacing hardcoded color classes with theme-based classes such as `primary` and `accent`.
  * Updated buttons, icons, links, headings, and badges to use consistent theme colors for a more cohesive visual experience.
  * No changes to functionality or content—only visual styling was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->