### PR TITLE
Add multistate support to LocalBusiness schema

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,6 +80,11 @@ export default function RootLayout({
               name: "Brink Design Co.",
               url: "https://www.brinkdesign.co",
               telephone: "605-381-8290",
+              areaServed: [
+                { "@type": "State", name: "South Dakota" },
+                { "@type": "State", name: "Wyoming" },
+                { "@type": "State", name: "Nebraska" },
+              ],
               address: {
                 "@type": "PostalAddress",
                 addressLocality: "Rapid City",


### PR DESCRIPTION
## Summary
- extend JSON-LD LocalBusiness snippet with `areaServed` entries for South Dakota, Wyoming, and Nebraska

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d18d369b0832189ad70090dbfe3a6