### PR TITLE
Add SEO enhancements with local branding

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -25,18 +25,18 @@ import {
 } from 'lucide-react';
 
 export const metadata: Metadata = {
-    title: "About Brink Design Co. - Rapid City AV & Low Voltage Experts",
-    description: "Learn how Brink Design Co. from Rapid City serves homes and businesses across South Dakota with expert low voltage installations and AV solutions.",
+    title: "About Brink Design – Low Voltage Specialists in Western South Dakota",
+    description: "Discover Brink Design, based in Sturgis and serving all of western South Dakota with expert low voltage installations and AV solutions for homes and businesses.",
     alternates: { canonical: "https://www.brinkdesign.co/about" },
     openGraph: {
-        title: "About Brink Design Co. - Rapid City AV & Low Voltage Experts",
-        description: "Learn how Brink Design Co. from Rapid City serves homes and businesses across South Dakota with expert low voltage installations and AV solutions.",
+        title: "About Brink Design – Low Voltage Specialists in Western South Dakota",
+        description: "Learn how Brink Design serves western South Dakota with professional cabling and AV services.",
         images: ["/og-image.jpg"],
     },
     twitter: {
         card: "summary_large_image",
-        title: "About Brink Design Co. - Rapid City AV & Low Voltage Experts",
-        description: "Learn how Brink Design Co. from Rapid City serves homes and businesses across South Dakota with expert low voltage installations and AV solutions.",
+        title: "About Brink Design – Low Voltage Specialists in Western South Dakota",
+        description: "Discover how we help homes and businesses across the Black Hills with expert AV installation.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -42,19 +42,19 @@ async function fetchBlogPosts() {
 }
 
 export const metadata: Metadata = {
-    title: "Professional AV & Technology Blog | Brink Design Co.",
-    description: "Expert insights on commercial AV systems, network infrastructure, security technology, and smart building solutions from South Dakota's leading AV professionals.",
+    title: "AV & Technology Blog – Brink Design Western South Dakota",
+    description: "Insights on commercial AV, networking and security from the low voltage experts serving Rapid City and all of western South Dakota.",
     alternates: { canonical: "https://www.brinkdesign.co/blog" },
     openGraph: {
-        title: "Professional AV & Technology Blog | Brink Design Co.",
-        description: "Expert insights on commercial AV systems, network infrastructure, security technology, and smart building solutions.",
+        title: "AV & Technology Blog – Brink Design Western South Dakota",
+        description: "Expert tips on AV systems, network infrastructure and security solutions across western South Dakota.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
         type: "website",
     },
     twitter: {
         card: "summary_large_image",
-        title: "Professional AV & Technology Blog | Brink Design Co.",
-        description: "Expert insights on commercial AV systems, network infrastructure, security technology, and smart building solutions.",
+        title: "AV & Technology Blog – Brink Design Western South Dakota",
+        description: "Latest insights on AV and low voltage installs across the Black Hills region.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,13 +2,21 @@ import { Metadata } from "next";
 import ContactContainer from "@/components/contact_container";
 
 export const metadata: Metadata = {
-  title: "Contact Brink Design Co. | Rapid City, SD",
-  description: "Reach out for professional AV, networking, security, and low voltage services in Rapid City and across South Dakota.",
+  title: "Contact Brink Design – Western South Dakota Low Voltage Experts",
+  description:
+    "Get in touch with Brink Design for professional AV installation, security cameras and cabling services across western South Dakota, including Sturgis and Rapid City.",
   alternates: { canonical: "https://www.brinkdesign.co/contact" },
+  openGraph: {
+    title: "Contact Brink Design – Western South Dakota Low Voltage Experts",
+    description:
+      "Reach out for professional AV, networking and security solutions across western South Dakota.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
   twitter: {
     card: "summary_large_image",
-    title: "Contact Brink Design Co. | Rapid City, SD",
-    description: "Reach out for professional AV, networking, security, and low voltage services in Rapid City and across South Dakota.",
+    title: "Contact Brink Design – Western South Dakota Low Voltage Experts",
+    description:
+      "Get in touch for AV, networking and security solutions in the Black Hills region.",
     images: ["https://www.brinkdesign.co/og-image.jpg"],
   },
 };

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -5,11 +5,11 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-    title: "FAQ – Brink Design Co.",
-    description: "Frequently asked questions about AV installation, security cameras, networking, and more from Brink Design Co. Serving Rapid City and the Black Hills.",
+    title: "FAQ – Brink Design Western South Dakota",
+    description: "Answers to common questions about AV installation, security cameras and cabling services for businesses and churches across western South Dakota.",
     openGraph: {
-        title: "FAQ – Brink Design Co.",
-        description: "Answers to common questions about our AV and low voltage services, process, support, and more.",
+        title: "FAQ – Brink Design Western South Dakota",
+        description: "Find details about our AV and low voltage process and support across the Black Hills.",
         url: "https://www.brinkdesign.co/faq",
         type: "article",
         images: [
@@ -24,8 +24,8 @@ export const metadata: Metadata = {
     alternates: { canonical: "https://www.brinkdesign.co/faq" },
     twitter: {
         card: "summary_large_image",
-        title: "FAQ – Brink Design Co.",
-        description: "Frequently asked questions about AV installation, security cameras, networking, and more from Brink Design Co. Serving Rapid City and the Black Hills.",
+        title: "FAQ – Brink Design Western South Dakota",
+        description: "Your questions answered about our AV and low voltage services in South Dakota.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,10 +1,10 @@
 export default function Head() {
   return (
     <>
-      <title>Brink Design | AV & Security Installers in SD</title>
+      <title>Brink Design – Low Voltage AV Installers in Western South Dakota</title>
       <meta
         name="description"
-        content="AV installs, low-voltage wiring, security systems & smart home solutions for churches, businesses, and homes across South Dakota."
+        content="Professional AV installation, low-voltage wiring and security systems serving the greater Rapid City area and all of western South Dakota."
       />
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,15 +9,15 @@ import { GA_ID } from "@/lib/analytics";
 
 export const metadata: Metadata = {
   title:
-    "Brink Design Co. | Low Voltage Cabling, AV Installer & Systems Integrator in South Dakota, Wyoming & Nebraska",
+    "Brink Design – Low Voltage AV Installer in Western South Dakota",
   description:
-    "Professional low voltage wiring, AV design, and security system installations for churches, businesses, and homes across South Dakota, Wyoming & Nebraska.",
+    "Professional low voltage wiring, AV design and security camera installations for churches, businesses and homes across western South Dakota.",
   robots: { index: true, follow: true },
   openGraph: {
     title:
-      "Brink Design Co. | Low Voltage Cabling, AV Installer & Systems Integrator in South Dakota, Wyoming & Nebraska",
+      "Brink Design – Low Voltage AV Installer in Western South Dakota",
     description:
-      "Professional low voltage wiring, AV design, and security system installations for churches, businesses, and homes across South Dakota, Wyoming & Nebraska.",
+      "Professional low voltage wiring, AV design and security installations for churches, businesses and homes throughout western South Dakota.",
     url: "https://www.brinkdesign.co",
     type: "website",
     images: [
@@ -33,9 +33,9 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title:
-      "Brink Design Co. | Low Voltage Cabling, AV Installer & Systems Integrator in South Dakota, Wyoming & Nebraska",
+      "Brink Design – Low Voltage AV Installer in Western South Dakota",
     description:
-      "Professional low voltage wiring, AV design, and security system installations for churches, businesses, and homes across South Dakota, Wyoming & Nebraska.",
+      "Professional AV and cabling solutions for homes and organizations across western South Dakota.",
     images: ["https://www.brinkdesign.co/og-image.jpg"],
   },
 };
@@ -56,6 +56,12 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link id="favicon" rel="icon" href="/favicon/favicon-light.png" />
+        {/* Google Tag Manager */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-XXXXXXX');`
+          }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `
@@ -102,6 +108,8 @@ export default function RootLayout({
         "min-h-screen bg-background font-sans antialiased",
         fontSans.variable
       )}>
+        {/* Google Tag Manager (noscript) */}
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style={{display:'none',visibility:'hidden'}}></iframe></noscript>
         <ConditionalLayout>
           {children}
         </ConditionalLayout>

--- a/src/app/linecard/page.tsx
+++ b/src/app/linecard/page.tsx
@@ -5,6 +5,24 @@ import Image from 'next/image';
 import Link from 'next/link';
 import Markdoc from '@markdoc/markdoc';
 import React from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'AV Line Card – Brink Design Western South Dakota',
+  description: 'View our preferred audio, video and technology partners for projects across western South Dakota.',
+  openGraph: {
+    title: 'AV Line Card – Brink Design Western South Dakota',
+    description: 'Discover the brands Brink Design trusts for professional AV and low voltage installations.',
+    images: ['https://www.brinkdesign.co/og-image.jpg'],
+  },
+  alternates: { canonical: 'https://www.brinkdesign.co/linecard' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'AV Line Card – Brink Design Western South Dakota',
+    description: 'Our trusted vendors for AV, security and networking equipment in South Dakota.',
+    images: ['https://www.brinkdesign.co/og-image.jpg'],
+  },
+};
 
 export default async function LineCardPage() {
   const reader = createReader(process.cwd(), keystaticConfig);

--- a/src/app/nebraska/page.tsx
+++ b/src/app/nebraska/page.tsx
@@ -2,13 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-    title: "Nebraska AV Installer & Systems Integrator - Brink Design Co.",
+    title: "Nebraska AV Installer – Brink Design Western South Dakota",
     description:
-        "Brink Design Co. offers expert AV installer and systems integrator services for Nebraska organizations and homes. We handle audio, video, networking, and security installations with professional care.",
+        "Brink Design provides expert audio, video and cabling services for churches and businesses across Nebraska from our base in western South Dakota.",
     openGraph: {
-        title: "Nebraska AV Installer & Systems Integrator - Brink Design Co.",
+        title: "Nebraska AV Installer – Brink Design Western South Dakota",
         description:
-            "Brink Design Co. offers expert AV installer and systems integrator services for Nebraska organizations and homes. We handle audio, video, networking, and security installations with professional care.",
+            "Professional AV integration and low voltage services for Nebraska facilities delivered by Brink Design.",
         url: "https://www.brinkdesign.co/nebraska",
         type: "article",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
@@ -16,9 +16,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "https://www.brinkdesign.co/nebraska" },
     twitter: {
         card: "summary_large_image",
-        title: "Nebraska AV Installer & Systems Integrator - Brink Design Co.",
+        title: "Nebraska AV Installer – Brink Design Western South Dakota",
         description:
-            "Brink Design Co. offers expert AV installer and systems integrator services for Nebraska organizations and homes. We handle audio, video, networking, and security installations with professional care.",
+            "AV installation and structured cabling solutions for Nebraska organizations from Brink Design.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/photo-booth-opt-in/page.tsx
+++ b/src/app/photo-booth-opt-in/page.tsx
@@ -1,13 +1,13 @@
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-    title: "Photo Booth Opt-In Policy - Brink Design Co.",
+    title: "Photo Booth Opt-In Policy – Brink Design Western South Dakota",
     description:
-        "Details on how we send your photo booth images via SMS and how to manage your consent and privacy preferences.",
+        "How Brink Design handles photo booth SMS delivery and privacy for events across western South Dakota.",
     openGraph: {
-        title: "Photo Booth Opt-In Policy - Brink Design Co.",
+        title: "Photo Booth Opt-In Policy – Brink Design Western South Dakota",
         description:
-            "Learn about our SMS photo delivery and privacy practices for Brink Design Co.'s photo booth.",
+            "Learn about our SMS photo delivery process and privacy practices for events in the Black Hills.",
         url: "https://www.brinkdesign.co/photo-booth-opt-in",
         type: "article",
         images: [
@@ -22,9 +22,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "https://www.brinkdesign.co/photo-booth-opt-in" },
     twitter: {
         card: "summary_large_image",
-        title: "Photo Booth Opt-In Policy - Brink Design Co.",
+        title: "Photo Booth Opt-In Policy – Brink Design Western South Dakota",
         description:
-            "Details on how we send your photo booth images via SMS and how to manage your consent and privacy preferences.",
+            "Information about receiving photos via SMS and controlling your privacy settings.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -2,13 +2,18 @@ import type { Metadata } from "next";
 import { Shield, Eye, Lock, FileText, Mail, CheckCircle, AlertTriangle } from "lucide-react";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy - Brink Design Co.",
-  description: "Learn how Brink Design Co. handles your information when providing AV installations, networking, and low voltage services.",
+  title: "Privacy Policy – Brink Design Western South Dakota",
+  description: "How Brink Design protects your data when delivering AV and security installations across western South Dakota.",
   alternates: { canonical: "https://www.brinkdesign.co/privacy-policy" },
+  openGraph: {
+    title: "Privacy Policy – Brink Design Western South Dakota",
+    description: "Understand how we safeguard customer information for projects across the Black Hills region.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
   twitter: {
     card: "summary_large_image",
-    title: "Privacy Policy - Brink Design Co.",
-    description: "Learn how Brink Design Co. handles your information when providing AV installations, networking, and low voltage services.",
+    title: "Privacy Policy – Brink Design Western South Dakota",
+    description: "Details on Brink Design's data practices and privacy protections.",
     images: ["https://www.brinkdesign.co/og-image.jpg"],
   },
 };

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -29,13 +29,21 @@ async function fetchProjects() {
 }
 
 export const metadata: Metadata = {
-  title: "Projects - Brink Design Co.",
-  description: "Browse our portfolio of AV installations and low voltage projects, including networking, security systems, door access, and more.",
+  title: "AV Projects – Brink Design Western South Dakota",
+  description:
+    "See our portfolio of AV installations, security systems and low voltage projects across western South Dakota.",
   alternates: { canonical: "https://www.brinkdesign.co/projects" },
+  openGraph: {
+    title: "AV Projects – Brink Design Western South Dakota",
+    description:
+      "Browse real-world examples of our cabling and audio/video work throughout the Black Hills region.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
   twitter: {
     card: "summary_large_image",
-    title: "Projects - Brink Design Co.",
-    description: "Browse our portfolio of AV installations and low voltage projects, including networking, security systems, door access, and more.",
+    title: "AV Projects – Brink Design Western South Dakota",
+    description:
+      "View professional AV and low voltage projects completed by Brink Design across South Dakota.",
     images: ["https://www.brinkdesign.co/og-image.jpg"],
   },
 };

--- a/src/app/service-area/page.tsx
+++ b/src/app/service-area/page.tsx
@@ -5,19 +5,20 @@ import Link from "next/link";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-    title: "Service Area - Brink Design Co.",
-    description: "Brink Design Co. provides professional AV and low voltage installations across South Dakota, Wyoming, and Nebraska. Explore our coverage area and services.",
+    title: "Service Area – Brink Design Western South Dakota",
+    description: "Brink Design provides AV installation and low voltage services throughout western South Dakota and nearby states.",
     openGraph: {
-        title: "Service Area - Brink Design Co.",
-        description: "Professional AV installations and low voltage solutions throughout South Dakota, Wyoming, and Nebraska.",
+        title: "Service Area – Brink Design Western South Dakota",
+        description: "Professional AV and cabling solutions across South Dakota, Wyoming and Nebraska.",
         url: "https://www.brinkdesign.co/service-area",
         type: "website",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
     alternates: { canonical: "https://www.brinkdesign.co/service-area" },
     twitter: {
         card: "summary_large_image",
-        title: "Service Area - Brink Design Co.",
-        description: "Brink Design Co. provides professional AV and low voltage installations across South Dakota, Wyoming, and Nebraska. Explore our coverage area and services.",
+        title: "Service Area – Brink Design Western South Dakota",
+        description: "Learn where Brink Design offers AV and security installations across the Black Hills region and beyond.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/services/commercial-av/page.tsx
+++ b/src/app/services/commercial-av/page.tsx
@@ -30,13 +30,13 @@ import {
 } from "lucide-react";
 
 export const metadata: Metadata = {
-    title: "Professional Commercial AV Installation - Brink Design Co.",
+    title: "Commercial AV Installation – Brink Design Western South Dakota",
     description:
-        "Expert commercial audio/video installation for businesses, churches, schools, and conference rooms. Custom AV systems designed for South Dakota organizations.",
+        "Professional audio and video systems for churches, schools and businesses across western South Dakota.",
     openGraph: {
-        title: "Professional Commercial AV Installation - Brink Design Co.",
+        title: "Commercial AV Installation – Brink Design Western South Dakota",
         description:
-            "Expert commercial audio/video installation for businesses, churches, schools, and conference rooms. Custom AV systems designed for South Dakota organizations.",
+            "Expert audio/video solutions for organizations in Sturgis, Rapid City and the surrounding area.",
         url: "https://www.brinkdesign.co/services/commercial-av",
         type: "article",
         images: [
@@ -51,9 +51,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "https://www.brinkdesign.co/services/commercial-av" },
     twitter: {
         card: "summary_large_image",
-        title: "Professional Commercial AV Installation - Brink Design Co.",
+        title: "Commercial AV Installation – Brink Design Western South Dakota",
         description:
-            "Expert commercial audio/video installation for businesses, churches, schools, and conference rooms. Custom AV systems designed for South Dakota organizations.",
+            "Professional AV systems and integration services for the Black Hills region.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/services/low-voltage/page.tsx
+++ b/src/app/services/low-voltage/page.tsx
@@ -26,20 +26,20 @@ import {
 } from "lucide-react";
 
 export const metadata: Metadata = {
-    title: "Professional Low Voltage Cabling Services - Brink Design Co.",
+    title: "Low Voltage Cabling – Brink Design Western South Dakota",
     description:
-        "Expert low voltage cabling installation for data, voice, video, and security systems. Serving South Dakota with professional structured wiring solutions for homes and businesses.",
+        "Expert low voltage cabling for data, voice, video and security systems across the Black Hills region.",
     alternates: { canonical: "https://www.brinkdesign.co/services/low-voltage" },
     openGraph: {
-        title: "Professional Low Voltage Cabling Services - Brink Design Co.",
-        description: "Expert low voltage cabling installation for data, voice, video, and security systems. Serving South Dakota with professional structured wiring solutions.",
+        title: "Low Voltage Cabling – Brink Design Western South Dakota",
+        description: "Professional structured wiring solutions for businesses and homes in western South Dakota.",
         images: ["/og-image.jpg"],
     },
     twitter: {
         card: "summary_large_image",
-        title: "Professional Low Voltage Cabling Services - Brink Design Co.",
+        title: "Low Voltage Cabling – Brink Design Western South Dakota",
         description:
-            "Expert low voltage cabling installation for data, voice, video, and security systems. Serving South Dakota with professional structured wiring solutions.",
+            "High-quality cabling installation for network and security infrastructure in Sturgis and Rapid City.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -47,13 +47,18 @@ const services = [
 ];
 
 export const metadata: Metadata = {
-    title: "Low Voltage Services in Rapid City - Brink Design Co.",
-    description: "Explore professional low voltage services for Rapid City and South Dakota, from security installs to network cabling and AV solutions.",
+    title: "Low Voltage Services – Brink Design Western South Dakota",
+    description: "Comprehensive cabling, AV installation and security camera services for businesses and homes across western South Dakota.",
     alternates: { canonical: "https://www.brinkdesign.co/services" },
+    openGraph: {
+        title: "Low Voltage Services – Brink Design Western South Dakota",
+        description: "Explore our cabling and AV solutions for churches, businesses and residences across western South Dakota.",
+        images: ["https://www.brinkdesign.co/og-image.jpg"],
+    },
     twitter: {
         card: "summary_large_image",
-        title: "Low Voltage Services in Rapid City - Brink Design Co.",
-        description: "Explore professional low voltage services for Rapid City and South Dakota, from security installs to network cabling and AV solutions.",
+        title: "Low Voltage Services – Brink Design Western South Dakota",
+        description: "Professional low voltage wiring, security and AV solutions in the Black Hills.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/services/security-cameras/page.tsx
+++ b/src/app/services/security-cameras/page.tsx
@@ -29,20 +29,20 @@ import {
 } from "lucide-react";
 
 export const metadata: Metadata = {
-    title: "Professional Security Camera Systems - Brink Design Co.",
+    title: "Security Camera Systems – Brink Design Western South Dakota",
     description:
-        "Expert security camera installation and monitoring systems for homes and businesses. Professional surveillance solutions with local recording, remote access, and no monthly fees.",
+        "Professional security camera installation with local recording and remote access for homes and businesses in western South Dakota.",
     alternates: { canonical: "https://www.brinkdesign.co/services/security-cameras" },
     openGraph: {
-        title: "Professional Security Camera Systems - Brink Design Co.",
-        description: "Expert security camera installation and monitoring systems for homes and businesses. Professional surveillance solutions with local recording and remote access.",
+        title: "Security Camera Systems – Brink Design Western South Dakota",
+        description: "Expert surveillance solutions and monitoring services for the Black Hills region.",
         images: ["/og-image.jpg"],
     },
     twitter: {
         card: "summary_large_image",
-        title: "Professional Security Camera Systems - Brink Design Co.",
+        title: "Security Camera Systems – Brink Design Western South Dakota",
         description:
-            "Expert security camera installation and monitoring systems for homes and businesses. Professional surveillance solutions with local recording and remote access.",
+            "Protect your property with professional CCTV installation from Brink Design based in western South Dakota.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,12 @@
 import { MetadataRoute } from 'next';
+import { reader } from '@/lib/reader';
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
-  return [
+  const blogSlugs = await reader.collections.blog.list();
+  const projectSlugs = await reader.collections.project.list();
+
+  const staticPages: MetadataRoute.Sitemap = [
     { url: 'https://www.brinkdesign.co', lastModified: now },
     { url: 'https://www.brinkdesign.co/about', lastModified: now },
     { url: 'https://www.brinkdesign.co/services', lastModified: now },
@@ -20,4 +24,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: 'https://www.brinkdesign.co/services/security-cameras', lastModified: now },
     { url: 'https://www.brinkdesign.co/privacy-policy', lastModified: now },
   ];
+
+  const blogUrls = blogSlugs.map((slug) => ({
+    url: `https://www.brinkdesign.co/blog/${slug}`,
+    lastModified: now,
+    changeFrequency: 'weekly' as const,
+  }));
+
+  const projectUrls = projectSlugs.map((slug) => ({
+    url: `https://www.brinkdesign.co/projects/${slug}`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+  }));
+
+  return [...staticPages, ...blogUrls, ...projectUrls];
 }

--- a/src/app/south-dakota/page.tsx
+++ b/src/app/south-dakota/page.tsx
@@ -2,13 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-    title: "South Dakota AV Installer & Systems Integrator - Brink Design Co.",
+    title: "South Dakota AV Installer – Brink Design Western SD",
     description:
-        "Brink Design Co. is the premier AV installer and systems integrator for South Dakota. We design and build audio, video, networking, and security solutions for businesses, churches, and homes statewide.",
+        "Brink Design delivers professional AV installation, security and network cabling solutions across South Dakota from our base in western South Dakota.",
     openGraph: {
-        title: "South Dakota AV Installer & Systems Integrator - Brink Design Co.",
+        title: "South Dakota AV Installer – Brink Design Western SD",
         description:
-            "Brink Design Co. is the premier AV installer and systems integrator for South Dakota. We design and build audio, video, networking, and security solutions for businesses, churches, and homes statewide.",
+            "Comprehensive audio, video and low voltage services for businesses and churches across South Dakota.",
         url: "https://www.brinkdesign.co/south-dakota",
         type: "article",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
@@ -16,9 +16,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "https://www.brinkdesign.co/south-dakota" },
     twitter: {
         card: "summary_large_image",
-        title: "South Dakota AV Installer & Systems Integrator - Brink Design Co.",
+        title: "South Dakota AV Installer – Brink Design Western SD",
         description:
-            "Brink Design Co. is the premier AV installer and systems integrator for South Dakota. We design and build audio, video, networking, and security solutions for businesses, churches, and homes statewide.",
+            "Expert AV and low voltage integration for the entire state of South Dakota.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/app/wyoming/page.tsx
+++ b/src/app/wyoming/page.tsx
@@ -2,13 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-    title: "Wyoming AV Installer & Systems Integrator - Brink Design Co.",
+    title: "Wyoming AV Installer – Brink Design Western South Dakota",
     description:
-        "Brink Design Co. provides professional AV installer and systems integrator services across Wyoming. We deliver custom audio, video, security, and networking solutions for organizations and homes.",
+        "Professional AV and low voltage services for organizations and homes throughout Wyoming delivered from nearby western South Dakota.",
     openGraph: {
-        title: "Wyoming AV Installer & Systems Integrator - Brink Design Co.",
+        title: "Wyoming AV Installer – Brink Design Western South Dakota",
         description:
-            "Brink Design Co. provides professional AV installer and systems integrator services across Wyoming. We deliver custom audio, video, security, and networking solutions for organizations and homes.",
+            "Expert audio, video and security solutions for Wyoming churches, businesses and homes.",
         url: "https://www.brinkdesign.co/wyoming",
         type: "article",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
@@ -16,9 +16,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "https://www.brinkdesign.co/wyoming" },
     twitter: {
         card: "summary_large_image",
-        title: "Wyoming AV Installer & Systems Integrator - Brink Design Co.",
+        title: "Wyoming AV Installer – Brink Design Western South Dakota",
         description:
-            "Brink Design Co. provides professional AV installer and systems integrator services across Wyoming. We deliver custom audio, video, security, and networking solutions for organizations and homes.",
+            "Custom AV installation and cabling services available for Wyoming from Brink Design.",
         images: ["https://www.brinkdesign.co/og-image.jpg"],
     },
 };

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -79,16 +79,12 @@ const Footer: React.FC = () => {
                                 <div className="absolute -bottom-2 left-0 w-12 h-0.5 bg-gradient-to-r from-secondary to-secondary/60"></div>
                             </h3>
                             
-                            <div className="space-y-4 mb-6">
-                                <div className="flex items-center space-x-3">
-                                    <a href="mailto:contact@brinkdesign.co" className="text-gray-300 hover:text-white transition-colors">
-                                        contact@brinkdesign.co
-                                    </a>
-                                </div>
-                                <div className="flex items-center space-x-3">
-                                    <span className="text-gray-400">South Dakota</span>
-                                </div>
-                            </div>
+                            <address className="not-italic space-y-1 mb-6 text-gray-300">
+                                <strong className="text-white block">Brink Design Co.</strong>
+                                <a href="tel:+16053818290" className="block hover:text-white transition-colors">(605) 381-8290</a>
+                                <a href="mailto:contact@brinkdesign.co" className="block hover:text-white transition-colors">contact@brinkdesign.co</a>
+                                <span className="block text-gray-400">Serving western South Dakota</span>
+                            </address>
 
                             <div className="bg-white/5 backdrop-blur-sm rounded-lg p-4 border border-white/10">
                                 <p className="text-sm mb-3 text-gray-300 font-medium">Ready to get started?</p>


### PR DESCRIPTION
## Summary
- inject GTM script and noscript fallback in layout
- update site metadata with Western South Dakota branding
- add OpenGraph info across pages
- enhance footer with address markup
- dynamically build sitemap from posts and projects

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d1e8ddc3483219531d1b4cc1c8fa7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEO and social sharing metadata to the line card page for improved discoverability.
  * Integrated Google Tag Manager for enhanced site analytics.

* **Refactor**
  * Updated footer contact section to a semantic address block with company name, clickable phone and email, and improved layout.

* **Style**
  * Revised branding and descriptions across all pages to emphasize Western South Dakota and the Black Hills region.

* **Documentation**
  * Enhanced metadata for all major pages, improving SEO and social media previews with updated titles, descriptions, and images.

* **Chores**
  * Improved sitemap generation to include dynamic blog and project URLs with accurate update frequencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->