### PR TITLE
feat: add unique metadata for home page

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,10 +1,10 @@
 export default function Head() {
   return (
     <>
-      <title>Brink Design – Low Voltage AV Installers in Western South Dakota</title>
+      <title>Brink Design Co. | AV & Low Voltage Services in Rapid City, SD</title>
       <meta
         name="description"
-        content="Professional AV installation, low-voltage wiring and security systems serving the greater Rapid City area and all of western South Dakota."
+        content="Brink Design provides professional audio/video installations, network cabling and security systems for businesses, churches and homes across Rapid City and western South Dakota."
       />
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,27 @@ import Hero from "@/components/hero";
 import Testimonials from "@/components/testimonials-server";
 import Services from "@/components/services";
 import FeaturedProjectsServer from "@/components/FeaturedProjectsServer";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Brink Design Co. – AV Installation, Network Cabling & Security Cameras in Rapid City",
+  description:
+    "Professional audio/video setups, structured cabling and security camera systems for businesses, churches and homes across Rapid City and western South Dakota.",
+  alternates: { canonical: "https://www.brinkdesign.co/" },
+  openGraph: {
+    title: "Brink Design Co. – AV Installation, Network Cabling & Security Cameras in Rapid City",
+    description:
+      "Professional AV installation, network cabling and security system integration serving Rapid City and the Black Hills.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Brink Design Co. – AV Installation, Network Cabling & Security Cameras in Rapid City",
+    description:
+      "Professional AV, cabling and security solutions for homes and businesses across western South Dakota.",
+    images: ["https://www.brinkdesign.co/og-image.jpg"],
+  },
+};
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- refine default site head metadata
- add targeted title and description for home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e33b8d6c8321843432a26db1e810