### PR TITLE
Turn global site chrome into lead-gen conversion funnels

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -27,6 +27,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: 'https://www.brinkdesign.co/business-wifi-networks-rapid-city', lastModified: now },
     { url: 'https://www.brinkdesign.co/home-network-installation-rapid-city', lastModified: now },
     { url: 'https://www.brinkdesign.co/whole-home-audio-rapid-city', lastModified: now },
+    { url: 'https://www.brinkdesign.co/smart-home-automation-black-hills', lastModified: now },
     { url: 'https://www.brinkdesign.co/church-av-installation-south-dakota', lastModified: now },
     { url: 'https://www.brinkdesign.co/privacy-policy', lastModified: now },
   ];

--- a/src/app/smart-home-automation-black-hills/page.tsx
+++ b/src/app/smart-home-automation-black-hills/page.tsx
@@ -1,0 +1,353 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Home,
+  Lightbulb,
+  ShieldCheck,
+  Wifi,
+  Phone,
+  CheckCircle,
+  ArrowRight,
+  Clock,
+  BadgeCheck,
+  MapPin,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export const metadata: Metadata = {
+  title: "Smart Home Automation Black Hills | Brink Design Rapid City",
+  description:
+    "Smart home automation installation in Rapid City and the Black Hills. Control lighting, climate, cameras, locks, and audio from one app with local support.",
+  alternates: {
+    canonical: "https://www.brinkdesign.co/smart-home-automation-black-hills",
+  },
+  openGraph: {
+    title: "Smart Home Automation Black Hills | Brink Design",
+    description:
+      "Professional smart home automation for Black Hills homeowners. Lighting, security, WiFi, and whole-home audio integrated in one system.",
+    url: "https://www.brinkdesign.co/smart-home-automation-black-hills",
+  },
+};
+
+const serviceSchema = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Smart Home Automation Installation",
+  provider: {
+    "@type": "LocalBusiness",
+    name: "Brink Design Co.",
+    url: "https://www.brinkdesign.co",
+    telephone: "+1-605-389-3261",
+  },
+  areaServed: [
+    { "@type": "City", name: "Rapid City" },
+    { "@type": "Place", name: "Black Hills" },
+    { "@type": "City", name: "Box Elder" },
+    { "@type": "City", name: "Spearfish" },
+    { "@type": "City", name: "Sturgis" },
+    { "@type": "City", name: "Hill City" },
+  ],
+  serviceType: "Smart Home Automation",
+};
+
+const faqs = [
+  {
+    question: "How much does smart home automation cost in the Black Hills?",
+    answer:
+      "Most projects start around $2,500 for foundational lighting, app control, and basic integration. Larger homes with full lighting scenes, climate, security, and multi-room audio can range from $8,000 to $40,000+. We give clear line-item pricing after a walkthrough.",
+  },
+  {
+    question: "Can you work with equipment I already own?",
+    answer:
+      "Yes. We often integrate existing routers, speakers, cameras, and smart devices when they meet reliability standards. If a device creates instability, we will tell you exactly why and provide upgrade options.",
+  },
+  {
+    question: "Do I need a custom home to install smart automation?",
+    answer:
+      "No. We design systems for both retrofit homes and new construction. Many of our Rapid City projects start with network and lighting upgrades, then expand over time.",
+  },
+  {
+    question: "What happens if something breaks later?",
+    answer:
+      "You get local support from a Black Hills team. We document your setup, provide training at handoff, and offer support plans for updates, troubleshooting, and expansion.",
+  },
+];
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
+    },
+  })),
+};
+
+const outcomes = [
+  "One app for lights, climate, security, and audio",
+  "Fewer app conflicts and fewer support headaches",
+  "Reliable automations that your whole family can use",
+  "Clear upgrade path for future additions",
+];
+
+const process = [
+  {
+    title: "1) Free Walkthrough",
+    copy: "We review your home, devices, and priorities in person across Rapid City and the Black Hills.",
+  },
+  {
+    title: "2) System Blueprint",
+    copy: "You get a clear plan with recommended gear, wiring needs, and budget tiers.",
+  },
+  {
+    title: "3) Professional Installation",
+    copy: "Our team installs, labels, tests, and documents everything for long-term reliability.",
+  },
+  {
+    title: "4) Training + Support",
+    copy: "We train your household and remain available for updates, changes, and future expansion.",
+  },
+];
+
+const areas = [
+  "Rapid City",
+  "Black Hills",
+  "Box Elder",
+  "Spearfish",
+  "Sturgis",
+  "Hill City",
+  "Keystone",
+  "Custer",
+];
+
+export default function SmartHomeAutomationBlackHillsPage() {
+  return (
+    <main className="bg-white">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+
+      <section className="bg-slate-950 py-20 text-white">
+        <div className="mx-auto grid max-w-6xl gap-10 px-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-blue-300">
+              Smart Home Automation in Rapid City & the Black Hills
+            </p>
+            <h1 className="mt-4 max-w-4xl text-4xl font-bold sm:text-5xl">
+              Turn Your Home Into a Predictable, Easy-to-Use Smart System
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg text-slate-200">
+              Brink Design builds smart homes that actually work day-to-day.
+              Lighting, climate, cameras, locks, and audio are designed around
+              reliability first, not gadget hype.
+            </p>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-2">
+              {outcomes.map((item) => (
+                <div key={item} className="flex items-start gap-2 rounded-lg bg-white/5 p-3 text-sm">
+                  <CheckCircle className="mt-0.5 h-4 w-4 text-emerald-400" />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-10 flex flex-wrap gap-4">
+              <Button asChild size="lg" className="font-semibold">
+                <Link href="/contact">Book a Free Walkthrough</Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="border-white/30 bg-transparent text-white hover:bg-white/10"
+              >
+                <a href="tel:6053893261" className="inline-flex items-center gap-2">
+                  <Phone className="h-4 w-4" />
+                  Call (605) 389-3261
+                </a>
+              </Button>
+            </div>
+          </div>
+
+          <aside className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="text-xl font-semibold">Free Smart Home Plan Session</h2>
+            <p className="mt-2 text-sm text-slate-200">
+              Get a no-pressure in-home strategy session with a practical roadmap
+              and pricing ranges.
+            </p>
+            <div className="mt-5 space-y-3 text-sm">
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 text-blue-300" />
+                30-45 minute walkthrough
+              </div>
+              <div className="flex items-center gap-2">
+                <BadgeCheck className="h-4 w-4 text-emerald-300" />
+                Upgrade roadmap + budget tiers
+              </div>
+              <div className="flex items-center gap-2">
+                <MapPin className="h-4 w-4 text-orange-300" />
+                Local Black Hills installer
+              </div>
+            </div>
+            <div className="mt-6 space-y-3">
+              <Button asChild className="w-full font-semibold">
+                <Link href="/contact">Claim Your Free Session</Link>
+              </Button>
+              <Link
+                href="/projects"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white hover:bg-white/10"
+              >
+                See Recent Install Projects
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="text-3xl font-bold text-slate-900">What We Integrate</h2>
+          <p className="mt-3 max-w-3xl text-slate-700">
+            We build the system architecture so every part talks to the others
+            reliably and can be controlled from one place.
+          </p>
+
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            <article className="rounded-xl border p-6">
+              <Lightbulb className="h-7 w-7 text-amber-500" />
+              <h3 className="mt-4 text-xl font-semibold">Lighting + Shade Scenes</h3>
+              <p className="mt-2 text-slate-700">
+                Morning, evening, movie, and away scenes that trigger
+                automatically or with one button.
+              </p>
+            </article>
+            <article className="rounded-xl border p-6">
+              <ShieldCheck className="h-7 w-7 text-emerald-500" />
+              <h3 className="mt-4 text-xl font-semibold">Cameras + Entry Security</h3>
+              <p className="mt-2 text-slate-700">
+                See and manage key security events from the same dashboard as the
+                rest of your home.
+              </p>
+            </article>
+            <article className="rounded-xl border p-6">
+              <Wifi className="h-7 w-7 text-sky-500" />
+              <h3 className="mt-4 text-xl font-semibold">Network-First Foundation</h3>
+              <p className="mt-2 text-slate-700">
+                Stable WiFi and structured cabling prevent the random outages and
+                lag common in DIY smart homes.
+              </p>
+            </article>
+            <article className="rounded-xl border p-6">
+              <Home className="h-7 w-7 text-indigo-500" />
+              <h3 className="mt-4 text-xl font-semibold">One Interface Your Family Uses</h3>
+              <p className="mt-2 text-slate-700">
+                We simplify controls so anyone can use the system without needing
+                ten separate apps.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-50 py-16">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="text-3xl font-bold text-slate-900">Our 4-Step Install Process</h2>
+          <div className="mt-8 grid gap-5 md:grid-cols-2">
+            {process.map((step) => (
+              <article key={step.title} className="rounded-xl border bg-white p-6">
+                <h3 className="text-lg font-semibold">{step.title}</h3>
+                <p className="mt-2 text-slate-700">{step.copy}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="text-3xl font-bold text-slate-900">Service Area</h2>
+          <p className="mt-3 text-slate-700">
+            We install smart home systems across Western South Dakota with a
+            focus on long-term local support.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {areas.map((area) => (
+              <span
+                key={area}
+                className="rounded-full border bg-slate-50 px-4 py-2 text-sm font-medium"
+              >
+                {area}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-950 py-16 text-white">
+        <div className="mx-auto max-w-4xl px-6">
+          <h2 className="text-3xl font-bold">Smart Home Automation FAQs</h2>
+          <Accordion type="single" collapsible className="mt-8 w-full">
+            {faqs.map((faq, idx) => (
+              <AccordionItem value={`item-${idx + 1}`} key={faq.question}>
+                <AccordionTrigger className="text-left text-base font-semibold">
+                  {faq.question}
+                </AccordionTrigger>
+                <AccordionContent className="text-slate-200">
+                  {faq.answer}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </section>
+
+      <section className="pb-20 pt-16">
+        <div className="mx-auto max-w-6xl rounded-2xl bg-slate-100 p-8 md:p-10">
+          <h2 className="text-3xl font-bold">Build Your Smart Home Roadmap</h2>
+          <p className="mt-3 max-w-3xl text-slate-700">
+            Start with the highest-impact upgrades now, then phase in additional
+            automation as your goals evolve.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Button asChild>
+              <Link href="/contact">Get a Free Consultation</Link>
+            </Button>
+            <Link
+              className="inline-flex items-center rounded-md border bg-white px-4 py-2 text-sm font-medium"
+              href="/whole-home-audio-rapid-city"
+            >
+              Whole-Home Audio Installation
+            </Link>
+            <Link
+              className="inline-flex items-center rounded-md border bg-white px-4 py-2 text-sm font-medium"
+              href="/home-network-installation-rapid-city"
+            >
+              Home Network Installation
+            </Link>
+            <Link
+              className="inline-flex items-center rounded-md border bg-white px-4 py-2 text-sm font-medium"
+              href="/commercial-security-cameras-rapid-city"
+            >
+              Security Camera Installation
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/ConditionalLayout.tsx
+++ b/src/components/ConditionalLayout.tsx
@@ -17,6 +17,7 @@ export default function ConditionalLayout({ children }: { children: React.ReactN
       ) : (
         <>
           <Header />
+          <StickyHeaderCTA />
           {children}
           <LogoCloud />
           <Footer />

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -66,10 +66,10 @@ export default function Header() {
     }, [isServicesOpen, servicesDropdownAnchor]);
 
     const serviceLinks = [
-        { href: "/services/smart-home", label: "Smart Home & Automation" },
-        { href: "/services/commercial-av", label: "Audio/Video" },
-        { href: "/services/low-voltage", label: "WiFi & Wiring" },
-        { href: "/services/security-cameras", label: "Security Systems" },
+        { href: "/smart-home-automation-black-hills", label: "Smart Home & Automation" },
+        { href: "/church-av-installation-south-dakota", label: "Audio/Video" },
+        { href: "/business-wifi-networks-rapid-city", label: "WiFi & Wiring" },
+        { href: "/commercial-security-cameras-rapid-city", label: "Security Systems" },
     ];
 
     if (isProjectsPage) return null;
@@ -77,20 +77,24 @@ export default function Header() {
     return (
         <>
             {/* Top Info Bar */}
-            <div className="bg-primary text-white py-2 px-4 text-sm hidden lg:block">
-                <div className="max-w-7xl mx-auto flex justify-between items-center">
+            <div className="hidden bg-primary px-4 py-2 text-sm text-white lg:block">
+                <div className="mx-auto flex max-w-7xl items-center justify-between">
                     <div className="flex items-center space-x-6">
-                        <div className="flex items-center space-x-2">
-                            <Phone className="w-4 h-4" />
+                        <a href="tel:6053893261" className="flex items-center space-x-2 hover:text-blue-100">
+                            <Phone className="h-4 w-4" />
                             <span>(605) 389-3261</span>
-                        </div>
+                        </a>
                         <div className="flex items-center space-x-2">
-                            <MapPin className="w-4 h-4" />
-                            <span>Serving South Dakota</span>
+                            <MapPin className="h-4 w-4" />
+                            <span>Serving Rapid City & the Black Hills</span>
                         </div>
                     </div>
-                    <div className="text-sm">
+                    <div className="flex items-center gap-4">
                         <span className="font-medium">Licensed & Insured • 2-Year Labor Warranty</span>
+                        <Link href="/contact" className="inline-flex items-center gap-1 rounded-full bg-white px-3 py-1 text-xs font-semibold text-primary hover:bg-blue-50">
+                            <Clock className="h-3.5 w-3.5" />
+                            Free Walkthroughs This Week
+                        </Link>
                     </div>
                 </div>
             </div>
@@ -186,16 +190,15 @@ export default function Header() {
                         </div>
 
                         {/* CTA Buttons */}
-                        <div className="hidden lg:flex items-center space-x-4">
-                            <a
-                                href="tel:6053893261"
-                                className="flex items-center space-x-2 text-gray-700 hover:text-blue-600 transition-colors duration-200"
-                            >
-                                <Phone className="w-4 h-4" />
-                                <span className="font-medium">(605) 389-3261</span>
-                            </a>
-                            <Button asChild >
-                                <Link href="/contact">Book a Site Visit & Quote</Link>
+                        <div className="hidden lg:flex items-center space-x-3">
+                            <Button asChild variant="outline" className="font-semibold">
+                                <a href="tel:6053893261" className="inline-flex items-center gap-2">
+                                    <Phone className="h-4 w-4" />
+                                    Call (605) 389-3261
+                                </a>
+                            </Button>
+                            <Button asChild className="font-semibold">
+                                <Link href="/contact">Book Free Walkthrough</Link>
                             </Button>
                         </div>
 
@@ -310,11 +313,16 @@ export default function Header() {
                             </nav>
 
                             {/* Mobile CTA */}
-                            <div className="pt-4 border-t border-gray-200">
-                                <Button asChild className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 rounded-lg shadow-sm">
+                            <div className="space-y-2 border-t border-gray-200 pt-4">
+                                <Button asChild className="w-full bg-blue-600 py-3 font-semibold text-white hover:bg-blue-700 rounded-lg shadow-sm">
                                     <Link href="/contact" onClick={() => setIsMobileMenuOpen(false)}>
-                                        Book a Site Visit & Quote
+                                        Book Free Walkthrough
                                     </Link>
+                                </Button>
+                                <Button asChild variant="outline" className="w-full font-semibold">
+                                    <a href="tel:6053893261" onClick={() => setIsMobileMenuOpen(false)}>
+                                        Call (605) 389-3261
+                                    </a>
                                 </Button>
                             </div>
                         </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -3,14 +3,12 @@
 import React from 'react';
 import Image from 'next/image';
 import { Button } from './ui/button';
-import Link from 'next/link'
-import { ArrowRight, Phone } from 'lucide-react';
-
+import Link from 'next/link';
+import { ArrowRight, Phone, ShieldCheck, Wifi, Speaker } from 'lucide-react';
 
 export default function Hero() {
     return (
-        <section className="relative min-h-[70vh] flex items-center bg-primary overflow-hidden">
-            {/* Background Image */}
+        <section className="relative min-h-[72vh] overflow-hidden bg-primary flex items-center">
             <Image
                 src="/hero.avif"
                 alt=""
@@ -20,37 +18,60 @@ export default function Hero() {
                 className="object-cover object-center opacity-15"
             />
 
-            <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-28">
+            <div className="relative z-10 mx-auto max-w-5xl px-4 py-20 sm:px-6 lg:px-8 lg:py-28">
                 <div className="max-w-3xl">
-                    <p className="text-sm font-semibold text-accent uppercase tracking-wide mb-3">
-                        Rapid City &bull; Black Hills &bull; Western SD
+                    <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-accent">
+                        Rapid City • Black Hills • Western SD
                     </p>
-                    <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-5 leading-[1.1]">
-                        Security & WiFi for Rapid City Businesses
+                    <h1 className="mb-5 text-4xl font-bold leading-[1.1] text-white md:text-5xl lg:text-6xl">
+                        Get a Fast, No-Guesswork Quote for Cameras, WiFi, AV & Smart Home
                     </h1>
-                    <p className="text-lg md:text-xl text-blue-100 mb-8 max-w-2xl leading-relaxed">
-                        We install commercial camera systems, business WiFi, and structured cabling — no monthly fees, no out-of-town contractors. Local service, quality installs.
+                    <p className="mb-8 max-w-2xl text-lg leading-relaxed text-blue-100 md:text-xl">
+                        We design, install, and support reliable systems for businesses,
+                        churches, and homes—so you get fewer headaches and a setup that
+                        works every day.
                     </p>
-                    <div className="flex flex-col sm:flex-row gap-3 mb-8">
-                        <Button asChild size="lg" className="bg-accent text-gray-900 hover:bg-yellow-300 font-bold px-8 py-4 text-base">
+
+                    <div className="mb-8 flex flex-col gap-3 sm:flex-row">
+                        <Button asChild size="lg" className="bg-accent px-8 py-4 text-base font-bold text-gray-900 hover:bg-yellow-300">
                             <Link href="/contact" className="inline-flex items-center">
                                 Book a Free Walkthrough
-                                <ArrowRight className="w-5 h-5 ml-2" />
+                                <ArrowRight className="ml-2 h-5 w-5" />
                             </Link>
                         </Button>
-                        <Button asChild size="lg" className="bg-white text-gray-900 hover:bg-gray-100 font-bold px-8 py-4 text-base">
+                        <Button asChild size="lg" className="bg-white px-8 py-4 text-base font-bold text-gray-900 hover:bg-gray-100">
                             <Link href="tel:6053893261" className="inline-flex items-center">
-                                (605) 389-3261
-                                <Phone className="w-4 h-4 ml-2" />
+                                Call (605) 389-3261
+                                <Phone className="ml-2 h-4 w-4" />
                             </Link>
                         </Button>
                     </div>
-                    <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-blue-200">
+
+                    <div className="mb-7 rounded-lg border border-white/20 bg-white/10 p-3 text-sm text-blue-100">
+                        <span className="font-semibold text-white">This week:</span> Free on-site walkthroughs available in Rapid City, Box Elder, Spearfish, and Sturgis.
+                    </div>
+
+                    <div className="mb-7 flex flex-wrap gap-x-6 gap-y-2 text-sm text-blue-200">
                         <span>Licensed &amp; Insured</span>
-                        <span className="text-blue-400">&bull;</span>
+                        <span className="text-blue-400">•</span>
                         <span>No Monthly Fees</span>
-                        <span className="text-blue-400">&bull;</span>
+                        <span className="text-blue-400">•</span>
                         <span>2-Year Warranty</span>
+                    </div>
+
+                    <div className="grid gap-2 text-sm sm:grid-cols-3">
+                        <Link href="/commercial-security-cameras-rapid-city" className="inline-flex items-center gap-2 rounded-md bg-white/10 px-3 py-2 text-blue-100 hover:bg-white/20">
+                            <ShieldCheck className="h-4 w-4" />
+                            Security Cameras
+                        </Link>
+                        <Link href="/business-wifi-networks-rapid-city" className="inline-flex items-center gap-2 rounded-md bg-white/10 px-3 py-2 text-blue-100 hover:bg-white/20">
+                            <Wifi className="h-4 w-4" />
+                            Business WiFi
+                        </Link>
+                        <Link href="/smart-home-automation-black-hills" className="inline-flex items-center gap-2 rounded-md bg-white/10 px-3 py-2 text-blue-100 hover:bg-white/20">
+                            <Speaker className="h-4 w-4" />
+                            Smart Home
+                        </Link>
                     </div>
                 </div>
             </div>

--- a/src/components/services.tsx
+++ b/src/components/services.tsx
@@ -10,7 +10,7 @@ const services = [
     title: 'Security Cameras',
     description: 'See your property from anywhere. Local recording, no monthly fees, and remote access on your phone.',
     features: ['No Monthly Fees', '4K Night Vision', 'Phone Alerts', 'Local Recording'],
-    href: '/services/security-cameras',
+    href: '/commercial-security-cameras-rapid-city',
     color: 'from-red-500 to-orange-500',
     bgColor: 'bg-red-50',
     textColor: 'text-red-600'
@@ -20,7 +20,7 @@ const services = [
     title: 'WiFi & Cabling',
     description: 'Fast, reliable coverage in every room. We run the wires and set up access points so your network just works.',
     features: ['Whole-Home WiFi', 'Structured Cabling', 'Dead Zone Fixes', 'Business Networks'],
-    href: '/services/low-voltage',
+    href: '/business-wifi-networks-rapid-city',
     color: 'from-blue-500 to-cyan-500',
     bgColor: 'bg-blue-50',
     textColor: 'text-blue-600'
@@ -30,7 +30,7 @@ const services = [
     title: 'Church & Commercial AV',
     description: 'Sound systems, projectors, and livestreaming that your team can actually run. Clear audio, simple controls.',
     features: ['Worship Audio', 'Livestreaming', 'Conference Rooms', 'Training Provided'],
-    href: '/services/commercial-av',
+    href: '/church-av-installation-south-dakota',
     color: 'from-purple-500 to-pink-500',
     bgColor: 'bg-purple-50',
     textColor: 'text-purple-600'
@@ -40,7 +40,7 @@ const services = [
     title: 'Smart Home',
     description: 'Lighting, shades, thermostats, and audio that work together—controlled from one app or your voice.',
     features: ['Lighting Control', 'Motorized Shades', 'Whole-Home Audio', 'Simple App Control'],
-    href: '/services/smart-home',
+    href: '/smart-home-automation-black-hills',
     color: 'from-green-500 to-emerald-500',
     bgColor: 'bg-green-50',
     textColor: 'text-green-600'

--- a/src/components/stickyHeaderCTA.tsx
+++ b/src/components/stickyHeaderCTA.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Phone, Calendar, X } from "lucide-react";
+import { Phone, Calendar, X, ArrowRight } from "lucide-react";
 
 export default function StickyHeaderCTA() {
     const [isVisible, setIsVisible] = useState(false);
@@ -10,56 +11,52 @@ export default function StickyHeaderCTA() {
 
     useEffect(() => {
         const handleScroll = () => {
-            // Show the sticky CTA after scrolling 200px
-            setIsVisible(window.scrollY > 200);
+            setIsVisible(window.scrollY > 220);
         };
 
         window.addEventListener("scroll", handleScroll);
         return () => window.removeEventListener("scroll", handleScroll);
     }, []);
 
-    const handleCallClick = () => {
-        window.location.href = "tel:+16053893261"; // Replace with your actual phone number
-    };
-
     if (isDismissed || !isVisible) {
         return null;
     }
 
     return (
-        <div className="fixed top-0 left-0 right-0 z-50 bg-primary text-primary-foreground shadow-lg animate-in slide-in-from-top duration-300">
-            <div className="container mx-auto px-4 py-3">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-4">
-                        <div className="hidden sm:block">
-                            <span className="font-semibold">Need Cameras, WiFi, or AV Installed?</span>
-                            <span className="ml-2 text-primary-foreground/80">Same-Day Quotes Available</span>
-                        </div>
-                        <div className="sm:hidden">
-                            <span className="font-semibold">Site Visit + Quote</span>
+        <div className="fixed bottom-0 left-0 right-0 z-[60] border-t border-primary/20 bg-white/95 shadow-2xl backdrop-blur">
+            <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <p className="text-sm font-semibold text-primary">
+                        Ready for Cameras, WiFi, AV, or Smart Home?
+                    </p>
+                    <p className="text-xs text-gray-600 sm:text-sm">
+                        Free site walkthrough + clear scope + no-pressure quote.
+                    </p>
+                </div>
 
-                        </div>
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                        <Button
-                            onClick={handleCallClick}
-                            variant="secondary"
-                            size="sm"
-                        >
-                            <Phone className="w-4 h-4 mr-1" />
-                            <span className="hidden sm:inline">Call Now</span>
-                            <span className="sm:hidden">Call</span>
-                        </Button>
-                        <Button
-                            onClick={() => setIsDismissed(true)}
-                            variant="ghost"
-                            size="sm"
-                            className="text-white hover:bg-white/20 p-1"
-                        >
-                            <X className="w-4 h-4" />
-                        </Button>
-                    </div>
+                <div className="flex items-center gap-2">
+                    <Button asChild size="sm" className="font-semibold">
+                        <Link href="/contact" className="inline-flex items-center gap-1">
+                            <Calendar className="h-4 w-4" />
+                            Book Free Walkthrough
+                        </Link>
+                    </Button>
+                    <Button asChild size="sm" variant="outline" className="font-semibold">
+                        <a href="tel:+16053893261" className="inline-flex items-center gap-1">
+                            <Phone className="h-4 w-4" />
+                            Call Now
+                            <ArrowRight className="h-3.5 w-3.5" />
+                        </a>
+                    </Button>
+                    <Button
+                        onClick={() => setIsDismissed(true)}
+                        variant="ghost"
+                        size="sm"
+                        className="p-1 text-gray-500 hover:bg-gray-100"
+                        aria-label="Dismiss call-to-action"
+                    >
+                        <X className="h-4 w-4" />
+                    </Button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Convert the entire site shell into a lead-generation funnel so every page drives contact intent rather than relying on a single landing page. 
- Surface a persistent, low-friction CTA once users scroll so calls and booking actions are available site-wide. 
- Route navigation to high-intent “money” pages to increase lead quality and funnel flow. 

### Description
- Added a bottom conversion rail component `StickyHeaderCTA` and enabled it globally for all non-keystatic routes by including it in `src/components/ConditionalLayout.tsx`. 
- Reworked the header (`src/components/header.tsx`) top bar and CTA area to emphasize local service, urgency ("Free Walkthroughs This Week"), stronger desktop CTAs, and mobile CTA parity, and updated the Services dropdown links to point at high-intent pages. 
- Rewrote the homepage hero (`src/components/hero.tsx`) to a direct-response layout with an offer-led headline, repeated CTAs, urgency strip, and quick links into key money pages. 
- Updated service routing in `src/components/services.tsx` and added a conversion-focused landing page at `src/app/smart-home-automation-black-hills/page.tsx` with structured data (`Service` and `FAQPage`) and dedicated offer block. 

### Testing
- Ran `npx eslint src/components/stickyHeaderCTA.tsx src/components/ConditionalLayout.tsx src/components/header.tsx src/components/hero.tsx`, which passed for the modified files. 
- Ran `npm run lint`, which failed due to pre-existing repository-wide lint issues (unrelated files triggering `react/no-unescaped-entities` and `react-hooks/error-boundaries`). 
- Started the dev server with `npm run dev`, the app served locally, and a homepage screenshot of the updated lead-gen UX was captured via Playwright (Firefox).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939c2110e88321ad5413bc21308c3f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Smart Home Automation service page for Black Hills area with detailed service information, FAQs, and area coverage map.
  * Introduced "Book Free Walkthrough" call-to-action across header and sticky footer element.
  * Added quick-access service links (Security Cameras, Business WiFi, Smart Home) to homepage.

* **Updates**
  * Service navigation links now direct to location-specific pages.
  * Updated geographic focus to Rapid City & Black Hills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->